### PR TITLE
Add ZFS-MODULE provides at linux-cachyos-*-zfs package

### DIFF
--- a/linux-bore/PKGBUILD
+++ b/linux-bore/PKGBUILD
@@ -1006,6 +1006,7 @@ _package-headers() {
 _package-zfs(){
     pkgdesc="zfs module for the $pkgdesc kernel"
     depends=('pahole' linux-$pkgsuffix=$_kernver)
+    provides=('ZFS-MODULE')
 
     cd ${srcdir}/"zfs"
     install -dm755 "$pkgdir/usr/lib/modules/${_kernver}-${pkgsuffix}"

--- a/linux-cachyos-bmq/PKGBUILD
+++ b/linux-cachyos-bmq/PKGBUILD
@@ -1006,6 +1006,7 @@ _package-headers() {
 _package-zfs(){
     pkgdesc="zfs module for the $pkgdesc kernel"
     depends=('pahole' linux-$pkgsuffix=$_kernver)
+    provides=('ZFS-MODULE')
 
     cd ${srcdir}/"zfs"
     install -dm755 "$pkgdir/usr/lib/modules/${_kernver}-${pkgsuffix}"

--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -1006,6 +1006,7 @@ _package-headers() {
 _package-zfs(){
     pkgdesc="zfs module for the $pkgdesc kernel"
     depends=('pahole' linux-$pkgsuffix=$_kernver)
+    provides=('ZFS-MODULE')
 
     cd ${srcdir}/"zfs"
     install -dm755 "$pkgdir/usr/lib/modules/${_kernver}-${pkgsuffix}"

--- a/linux-cachyos-cacule/PKGBUILD
+++ b/linux-cachyos-cacule/PKGBUILD
@@ -1006,6 +1006,7 @@ _package-headers() {
 _package-zfs(){
     pkgdesc="zfs module for the $pkgdesc kernel"
     depends=('pahole' linux-$pkgsuffix=$_kernver)
+    provides=('ZFS-MODULE')
 
     cd ${srcdir}/"zfs"
     install -dm755 "$pkgdir/usr/lib/modules/${_kernver}-${pkgsuffix}"

--- a/linux-cachyos-cfs/PKGBUILD
+++ b/linux-cachyos-cfs/PKGBUILD
@@ -1006,6 +1006,7 @@ _package-headers() {
 _package-zfs(){
     pkgdesc="zfs module for the $pkgdesc kernel"
     depends=('pahole' linux-$pkgsuffix=$_kernver)
+    provides=('ZFS-MODULE')
 
     cd ${srcdir}/"zfs"
     install -dm755 "$pkgdir/usr/lib/modules/${_kernver}-${pkgsuffix}"

--- a/linux-cachyos-hardened/PKGBUILD
+++ b/linux-cachyos-hardened/PKGBUILD
@@ -1010,6 +1010,7 @@ _package-headers() {
 _package-zfs(){
     pkgdesc="zfs module for the $pkgdesc kernel"
     depends=('pahole' linux-$pkgsuffix=$_kernver)
+    provides=('ZFS-MODULE')
 
     cd ${srcdir}/"zfs"
     install -dm755 "$pkgdir/usr/lib/modules/${_kernver}-${pkgsuffix}"

--- a/linux-cachyos-pds/PKGBUILD
+++ b/linux-cachyos-pds/PKGBUILD
@@ -1006,6 +1006,7 @@ _package-headers() {
 _package-zfs(){
     pkgdesc="zfs module for the $pkgdesc kernel"
     depends=('pahole' linux-$pkgsuffix=$_kernver)
+    provides=('ZFS-MODULE')
 
     cd ${srcdir}/"zfs"
     install -dm755 "$pkgdir/usr/lib/modules/${_kernver}-${pkgsuffix}"

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -1000,6 +1000,7 @@ _package-headers() {
 _package-zfs(){
     pkgdesc="zfs module for the $pkgdesc kernel"
     depends=('pahole' linux-$pkgsuffix=$_kernver)
+    provides=('ZFS-MODULE')
 
     cd ${srcdir}/"zfs"
 	install -dm755 "$pkgdir/usr/lib/modules/${_major}.${_minor}-${_rcver}-${pkgrel}-${pkgsuffix}"

--- a/linux-cachyos-tt/PKGBUILD
+++ b/linux-cachyos-tt/PKGBUILD
@@ -1006,6 +1006,7 @@ _package-headers() {
 _package-zfs(){
     pkgdesc="zfs module for the $pkgdesc kernel"
     depends=('pahole' linux-$pkgsuffix=$_kernver)
+    provides=('ZFS-MODULE')
 
     cd ${srcdir}/"zfs"
     install -dm755 "$pkgdir/usr/lib/modules/${_kernver}-${pkgsuffix}"

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -1006,6 +1006,7 @@ _package-headers() {
 _package-zfs(){
     pkgdesc="zfs module for the $pkgdesc kernel"
     depends=('pahole' linux-$pkgsuffix=$_kernver)
+    provides=('ZFS-MODULE')
 
     cd ${srcdir}/"zfs"
     install -dm755 "$pkgdir/usr/lib/modules/${_kernver}-${pkgsuffix}"

--- a/linux-cacule-rdb/PKGBUILD
+++ b/linux-cacule-rdb/PKGBUILD
@@ -1006,6 +1006,7 @@ _package-headers() {
 _package-zfs(){
     pkgdesc="zfs module for the $pkgdesc kernel"
     depends=('pahole' linux-$pkgsuffix=$_kernver)
+    provides=('ZFS-MODULE')
 
     cd ${srcdir}/"zfs"
     install -dm755 "$pkgdir/usr/lib/modules/${_kernver}-${pkgsuffix}"

--- a/linux-cacule/PKGBUILD
+++ b/linux-cacule/PKGBUILD
@@ -1006,6 +1006,7 @@ _package-headers() {
 _package-zfs(){
     pkgdesc="zfs module for the $pkgdesc kernel"
     depends=('pahole' linux-$pkgsuffix=$_kernver)
+    provides=('ZFS-MODULE')
 
     cd ${srcdir}/"zfs"
     install -dm755 "$pkgdir/usr/lib/modules/${_kernver}-${pkgsuffix}"

--- a/linux-tt/PKGBUILD
+++ b/linux-tt/PKGBUILD
@@ -1006,6 +1006,7 @@ _package-headers() {
 _package-zfs(){
     pkgdesc="zfs module for the $pkgdesc kernel"
     depends=('pahole' linux-$pkgsuffix=$_kernver)
+    provides=('ZFS-MODULE')
 
     cd ${srcdir}/"zfs"
     install -dm755 "$pkgdir/usr/lib/modules/${_kernver}-${pkgsuffix}"


### PR DESCRIPTION
Zhe "zfs-meta" will be added with 6.1.9 and further. As soon these Kernels are in the repo it will be also added to the cachyos installer

Signed-off-by: Peter Jung <admin@ptr1337.dev>