### PR TITLE
ci: Move the pkgbuild-action fork to CachyOS

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Build (GCC)
       id: makepkg
-      uses: ventureoo/pkgbuild-action@master
+      uses: CachyOS/pkgbuild-action@master
       with:
         envvars: "_build_zfs=y _use_auto_optimization= _processor_opt=generic _cc_harder=" 
         pkgdir: "linux-cachyos"
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Build (LLVM)
       id: makepkg
-      uses: ventureoo/pkgbuild-action@master
+      uses: CachyOS/pkgbuild-action@master
       with:
         envvars: "_build_zfs=y _use_llvm_lto=thin _use_auto_optimization= _processor_opt=generic _cc_harder="
         pkgdir: "linux-cachyos"


### PR DESCRIPTION
Fixes: https://github.com/CachyOS/linux-cachyos/pull/72