### PR TITLE
Reactivate I/O schedulers

### DIFF
--- a/linux-bore/PKGBUILD
+++ b/linux-bore/PKGBUILD
@@ -87,10 +87,10 @@ _tickrate=${_tickrate-full}
 _preempt=${_preempt-full}
 
 ### Disable MQ-Deadline I/O scheduler
-_mq_deadline_disable=${_mq_deadline_disable-y}
+_mq_deadline_disable=${_mq_deadline_disable-}
 
 ### Disable Kyber I/O scheduler
-_kyber_disable=${_kyber_disable-y}
+_kyber_disable=${_kyber_disable-}
 
 ### Enable multigenerational LRU
 # ATTENTION - one of three predefined values should be selected!

--- a/linux-cachyos-bmq/PKGBUILD
+++ b/linux-cachyos-bmq/PKGBUILD
@@ -87,10 +87,10 @@ _tickrate=${_tickrate-full}
 _preempt=${_preempt-full}
 
 ### Disable MQ-Deadline I/O scheduler
-_mq_deadline_disable=${_mq_deadline_disable-y}
+_mq_deadline_disable=${_mq_deadline_disable-}
 
 ### Disable Kyber I/O scheduler
-_kyber_disable=${_kyber_disable-y}
+_kyber_disable=${_kyber_disable-}
 
 ### Enable multigenerational LRU
 # ATTENTION - one of three predefined values should be selected!

--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -87,10 +87,10 @@ _tickrate=${_tickrate-full}
 _preempt=${_preempt-full}
 
 ### Disable MQ-Deadline I/O scheduler
-_mq_deadline_disable=${_mq_deadline_disable-y}
+_mq_deadline_disable=${_mq_deadline_disable-}
 
 ### Disable Kyber I/O scheduler
-_kyber_disable=${_kyber_disable-y}
+_kyber_disable=${_kyber_disable-}
 
 ### Enable multigenerational LRU
 # ATTENTION - one of three predefined values should be selected!

--- a/linux-cachyos-cfs/PKGBUILD
+++ b/linux-cachyos-cfs/PKGBUILD
@@ -87,10 +87,10 @@ _tickrate=${_tickrate-full}
 _preempt=${_preempt-full}
 
 ### Disable MQ-Deadline I/O scheduler
-_mq_deadline_disable=${_mq_deadline_disable-y}
+_mq_deadline_disable=${_mq_deadline_disable-}
 
 ### Disable Kyber I/O scheduler
-_kyber_disable=${_kyber_disable-y}
+_kyber_disable=${_kyber_disable-}
 
 ### Enable multigenerational LRU
 # ATTENTION - one of three predefined values should be selected!

--- a/linux-cachyos-eevdf/PKGBUILD
+++ b/linux-cachyos-eevdf/PKGBUILD
@@ -87,10 +87,10 @@ _tickrate=${_tickrate-full}
 _preempt=${_preempt-full}
 
 ### Disable MQ-Deadline I/O scheduler
-_mq_deadline_disable=${_mq_deadline_disable-y}
+_mq_deadline_disable=${_mq_deadline_disable-}
 
 ### Disable Kyber I/O scheduler
-_kyber_disable=${_kyber_disable-y}
+_kyber_disable=${_kyber_disable-}
 
 ### Enable multigenerational LRU
 # ATTENTION - one of three predefined values should be selected!

--- a/linux-cachyos-hardened/PKGBUILD
+++ b/linux-cachyos-hardened/PKGBUILD
@@ -87,10 +87,10 @@ _tickrate=${_tickrate-full}
 _preempt=${_preempt-full}
 
 ### Disable MQ-Deadline I/O scheduler
-_mq_deadline_disable=${_mq_deadline_disable-y}
+_mq_deadline_disable=${_mq_deadline_disable-}
 
 ### Disable Kyber I/O scheduler
-_kyber_disable=${_kyber_disable-y}
+_kyber_disable=${_kyber_disable-}
 
 ### Enable multigenerational LRU
 # ATTENTION - one of three predefined values should be selected!

--- a/linux-cachyos-lts/PKGBUILD
+++ b/linux-cachyos-lts/PKGBUILD
@@ -85,10 +85,10 @@ _tickrate=${_tickrate-full}
 _preempt=${_preempt-full}
 
 ### Disable MQ-Deadline I/O scheduler
-_mq_deadline_disable=${_mq_deadline_disable-y}
+_mq_deadline_disable=${_mq_deadline_disable-}
 
 ### Disable Kyber I/O scheduler
-_kyber_disable=${_kyber_disable-y}
+_kyber_disable=${_kyber_disable-}
 
 ### Enable multigenerational LRU
 # ATTENTION - one of three predefined values should be selected!

--- a/linux-cachyos-pds/PKGBUILD
+++ b/linux-cachyos-pds/PKGBUILD
@@ -87,10 +87,10 @@ _tickrate=${_tickrate-full}
 _preempt=${_preempt-full}
 
 ### Disable MQ-Deadline I/O scheduler
-_mq_deadline_disable=${_mq_deadline_disable-y}
+_mq_deadline_disable=${_mq_deadline_disable-}
 
 ### Disable Kyber I/O scheduler
-_kyber_disable=${_kyber_disable-y}
+_kyber_disable=${_kyber_disable-}
 
 ### Enable multigenerational LRU
 # ATTENTION - one of three predefined values should be selected!

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -87,10 +87,10 @@ _tickrate=${_tickrate-full}
 _preempt=${_preempt-full}
 
 ### Disable MQ-Deadline I/O scheduler
-_mq_deadline_disable=${_mq_deadline_disable-y}
+_mq_deadline_disable=${_mq_deadline_disable-}
 
 ### Disable Kyber I/O scheduler
-_kyber_disable=${_kyber_disable-y}
+_kyber_disable=${_kyber_disable-}
 
 ### Enable multigenerational LRU
 # ATTENTION - one of three predefined values should be selected!

--- a/linux-cachyos-rt/PKGBUILD
+++ b/linux-cachyos-rt/PKGBUILD
@@ -87,10 +87,10 @@ _tickrate=${_tickrate-idle}
 _preempt=${_preempt-full}
 
 ### Disable MQ-Deadline I/O scheduler
-_mq_deadline_disable=${_mq_deadline_disable-y}
+_mq_deadline_disable=${_mq_deadline_disable-}
 
 ### Disable Kyber I/O scheduler
-_kyber_disable=${_kyber_disable-y}
+_kyber_disable=${_kyber_disable-}
 
 ### Enable multigenerational LRU
 # ATTENTION - one of three predefined values should be selected!

--- a/linux-cachyos-server/PKGBUILD
+++ b/linux-cachyos-server/PKGBUILD
@@ -90,7 +90,7 @@ _preempt=${_preempt-server}
 _mq_deadline_disable=${_mq_deadline_disable-}
 
 ### Disable Kyber I/O scheduler
-_kyber_disable=${_kyber_disable-y}
+_kyber_disable=${_kyber_disable-}
 
 ### Enable multigenerational LRU
 # ATTENTION - one of three predefined values should be selected!

--- a/linux-cachyos-tt/PKGBUILD
+++ b/linux-cachyos-tt/PKGBUILD
@@ -87,10 +87,10 @@ _tickrate=${_tickrate-full}
 _preempt=${_preempt-full}
 
 ### Disable MQ-Deadline I/O scheduler
-_mq_deadline_disable=${_mq_deadline_disable-y}
+_mq_deadline_disable=${_mq_deadline_disable-}
 
 ### Disable Kyber I/O scheduler
-_kyber_disable=${_kyber_disable-y}
+_kyber_disable=${_kyber_disable-}
 
 ### Enable multigenerational LRU
 # ATTENTION - one of three predefined values should be selected!

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -87,10 +87,10 @@ _tickrate=${_tickrate-full}
 _preempt=${_preempt-full}
 
 ### Disable MQ-Deadline I/O scheduler
-_mq_deadline_disable=${_mq_deadline_disable-y}
+_mq_deadline_disable=${_mq_deadline_disable-}
 
 ### Disable Kyber I/O scheduler
-_kyber_disable=${_kyber_disable-y}
+_kyber_disable=${_kyber_disable-}
 
 ### Enable multigenerational LRU
 # ATTENTION - one of three predefined values should be selected!

--- a/linux-tt/PKGBUILD
+++ b/linux-tt/PKGBUILD
@@ -87,10 +87,10 @@ _tickrate=${_tickrate-full}
 _preempt=${_preempt-full}
 
 ### Disable MQ-Deadline I/O scheduler
-_mq_deadline_disable=${_mq_deadline_disable-y}
+_mq_deadline_disable=${_mq_deadline_disable-}
 
 ### Disable Kyber I/O scheduler
-_kyber_disable=${_kyber_disable-y}
+_kyber_disable=${_kyber_disable-}
 
 ### Enable multigenerational LRU
 # ATTENTION - one of three predefined values should be selected!


### PR DESCRIPTION
I noticed that for example this line:
_mq_deadline_disable=${_mq_deadline_disable-y}

Wasn't doing anything since mq-deadline gets used anyways, so maybe it's impossible to remove, since this is the case on CachyOS in udev rules, i think it's better to just leave it and let the user decide which I/O scheduler to use at runtime.

Also kyber can be useful in some cases so it's better to have another alternative too.