### PR TITLE
Revert: Prevent ZFS and bcachefs building at the same time (issue #152 is solved now)

### DIFF
--- a/linux-bore/PKGBUILD
+++ b/linux-bore/PKGBUILD
@@ -296,12 +296,6 @@ prepare() {
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
-    ### Prevent ZFS and bcachefs building at the same time
-    # More infos here: https://github.com/CachyOS/linux-cachyos/issues/152
-    if [[ -n "$_bcachefs" && -n "$_build_zfs"  ]]; then
-        _die "ZFS and bcachefs support cannot be built at the same time. "
-    fi
-
     ### Prevent ZFS and LTO building at the same time
     # More infos here: https://github.com/openzfs/zfs/issues/15384
     if [[ "$_use_llvm_lto" != "none" && -n "$_build_zfs"  ]]; then

--- a/linux-cachyos-bore-rt/PKGBUILD
+++ b/linux-cachyos-bore-rt/PKGBUILD
@@ -296,12 +296,6 @@ prepare() {
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
-    ### Prevent ZFS and bcachefs building at the same time
-    # More infos here: https://github.com/CachyOS/linux-cachyos/issues/152
-    if [[ -n "$_bcachefs" && -n "$_build_zfs"  ]]; then
-        _die "ZFS and bcachefs support cannot be built at the same time. "
-    fi
-
     ### Prevent ZFS and LTO building at the same time
     # More infos here: https://github.com/openzfs/zfs/issues/15384
     if [[ "$_use_llvm_lto" != "none" && -n "$_build_zfs"  ]]; then

--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -296,12 +296,6 @@ prepare() {
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
-    ### Prevent ZFS and bcachefs building at the same time
-    # More infos here: https://github.com/CachyOS/linux-cachyos/issues/152
-    if [[ -n "$_bcachefs" && -n "$_build_zfs"  ]]; then
-        _die "ZFS and bcachefs support cannot be built at the same time. "
-    fi
-
     ### Prevent ZFS and LTO building at the same time
     # More infos here: https://github.com/openzfs/zfs/issues/15384
     if [[ "$_use_llvm_lto" != "none" && -n "$_build_zfs"  ]]; then

--- a/linux-cachyos-eevdf/PKGBUILD
+++ b/linux-cachyos-eevdf/PKGBUILD
@@ -296,12 +296,6 @@ prepare() {
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
-    ### Prevent ZFS and bcachefs building at the same time
-    # More infos here: https://github.com/CachyOS/linux-cachyos/issues/152
-    if [[ -n "$_bcachefs" && -n "$_build_zfs"  ]]; then
-        _die "ZFS and bcachefs support cannot be built at the same time. "
-    fi
-
     ### Prevent ZFS and LTO building at the same time
     # More infos here: https://github.com/openzfs/zfs/issues/15384
     if [[ "$_use_llvm_lto" != "none" && -n "$_build_zfs"  ]]; then

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -295,12 +295,6 @@ prepare() {
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
-    ### Prevent ZFS and bcachefs building at the same time
-    # More infos here: https://github.com/CachyOS/linux-cachyos/issues/152
-    if [[ -n "$_bcachefs" && -n "$_build_zfs"  ]]; then
-        _die "ZFS and bcachefs support cannot be built at the same time. "
-    fi
-
     ### Prevent ZFS and LTO building at the same time
     # More infos here: https://github.com/openzfs/zfs/issues/15384
     if [[ "$_use_llvm_lto" != "none" && -n "$_build_zfs"  ]]; then

--- a/linux-cachyos-rt/PKGBUILD
+++ b/linux-cachyos-rt/PKGBUILD
@@ -296,12 +296,6 @@ prepare() {
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
-    ### Prevent ZFS and bcachefs building at the same time
-    # More infos here: https://github.com/CachyOS/linux-cachyos/issues/152
-    if [[ -n "$_bcachefs" && -n "$_build_zfs"  ]]; then
-        _die "ZFS and bcachefs support cannot be built at the same time. "
-    fi
-
     ### Prevent ZFS and LTO building at the same time
     # More infos here: https://github.com/openzfs/zfs/issues/15384
     if [[ "$_use_llvm_lto" != "none" && -n "$_build_zfs"  ]]; then

--- a/linux-cachyos-server/PKGBUILD
+++ b/linux-cachyos-server/PKGBUILD
@@ -296,12 +296,6 @@ prepare() {
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
-    ### Prevent ZFS and bcachefs building at the same time
-    # More infos here: https://github.com/CachyOS/linux-cachyos/issues/152
-    if [[ -n "$_bcachefs" && -n "$_build_zfs"  ]]; then
-        _die "ZFS and bcachefs support cannot be built at the same time. "
-    fi
-
     ### Prevent ZFS and LTO building at the same time
     # More infos here: https://github.com/openzfs/zfs/issues/15384
     if [[ "$_use_llvm_lto" != "none" && -n "$_build_zfs"  ]]; then

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -296,12 +296,6 @@ prepare() {
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
-    ### Prevent ZFS and bcachefs building at the same time
-    # More infos here: https://github.com/CachyOS/linux-cachyos/issues/152
-    if [[ -n "$_bcachefs" && -n "$_build_zfs"  ]]; then
-        _die "ZFS and bcachefs support cannot be built at the same time. "
-    fi
-
     ### Prevent ZFS and LTO building at the same time
     # More infos here: https://github.com/openzfs/zfs/issues/15384
     if [[ "$_use_llvm_lto" != "none" && -n "$_build_zfs"  ]]; then


### PR DESCRIPTION
We can remove our workaround: https://github.com/CachyOS/linux-cachyos/issues/152