### PR TITLE
6.6 Add scx_layered && set alphabetical order in sched-ext-schedulers package

### DIFF
--- a/linux-bore/PKGBUILD
+++ b/linux-bore/PKGBUILD
@@ -846,13 +846,13 @@ _package-schedulers() {
 
    install -Dm755 scx_central "$pkgdir"/usr/bin/scx_central
    install -Dm755 scx_flatcg "$pkgdir"/usr/bin/scx_flatcg
+   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
+   install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
    install -Dm755 scx_pair "$pkgdir"/usr/bin/scx_pair
    install -Dm755 scx_qmap "$pkgdir"/usr/bin/scx_qmap
    install -Dm755 scx_rusty "$pkgdir"/usr/bin/scx_rusty
    install -Dm755 scx_simple "$pkgdir"/usr/bin/scx_simple
    install -Dm755 scx_userland "$pkgdir"/usr/bin/scx_userland
-   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
-   install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
 }
 
 pkgname=("$pkgbase" "$pkgbase-headers")

--- a/linux-bore/PKGBUILD
+++ b/linux-bore/PKGBUILD
@@ -851,6 +851,7 @@ _package-schedulers() {
    install -Dm755 scx_rusty "$pkgdir"/usr/bin/scx_rusty
    install -Dm755 scx_simple "$pkgdir"/usr/bin/scx_simple
    install -Dm755 scx_userland "$pkgdir"/usr/bin/scx_userland
+   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
    install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
 }
 

--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -846,13 +846,13 @@ _package-schedulers() {
 
    install -Dm755 scx_central "$pkgdir"/usr/bin/scx_central
    install -Dm755 scx_flatcg "$pkgdir"/usr/bin/scx_flatcg
+   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
+   install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
    install -Dm755 scx_pair "$pkgdir"/usr/bin/scx_pair
    install -Dm755 scx_qmap "$pkgdir"/usr/bin/scx_qmap
    install -Dm755 scx_rusty "$pkgdir"/usr/bin/scx_rusty
    install -Dm755 scx_simple "$pkgdir"/usr/bin/scx_simple
    install -Dm755 scx_userland "$pkgdir"/usr/bin/scx_userland
-   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
-   install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
 }
 
 pkgname=("$pkgbase" "$pkgbase-headers")

--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -851,6 +851,7 @@ _package-schedulers() {
    install -Dm755 scx_rusty "$pkgdir"/usr/bin/scx_rusty
    install -Dm755 scx_simple "$pkgdir"/usr/bin/scx_simple
    install -Dm755 scx_userland "$pkgdir"/usr/bin/scx_userland
+   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
    install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
 }
 

--- a/linux-cachyos-eevdf/PKGBUILD
+++ b/linux-cachyos-eevdf/PKGBUILD
@@ -846,13 +846,13 @@ _package-schedulers() {
 
    install -Dm755 scx_central "$pkgdir"/usr/bin/scx_central
    install -Dm755 scx_flatcg "$pkgdir"/usr/bin/scx_flatcg
+   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
+   install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
    install -Dm755 scx_pair "$pkgdir"/usr/bin/scx_pair
    install -Dm755 scx_qmap "$pkgdir"/usr/bin/scx_qmap
    install -Dm755 scx_rusty "$pkgdir"/usr/bin/scx_rusty
    install -Dm755 scx_simple "$pkgdir"/usr/bin/scx_simple
    install -Dm755 scx_userland "$pkgdir"/usr/bin/scx_userland
-   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
-   install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
 }
 
 pkgname=("$pkgbase" "$pkgbase-headers")

--- a/linux-cachyos-eevdf/PKGBUILD
+++ b/linux-cachyos-eevdf/PKGBUILD
@@ -851,6 +851,7 @@ _package-schedulers() {
    install -Dm755 scx_rusty "$pkgdir"/usr/bin/scx_rusty
    install -Dm755 scx_simple "$pkgdir"/usr/bin/scx_simple
    install -Dm755 scx_userland "$pkgdir"/usr/bin/scx_userland
+   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
    install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
 }
 

--- a/linux-cachyos-rt-bore/PKGBUILD
+++ b/linux-cachyos-rt-bore/PKGBUILD
@@ -846,13 +846,13 @@ _package-schedulers() {
 
    install -Dm755 scx_central "$pkgdir"/usr/bin/scx_central
    install -Dm755 scx_flatcg "$pkgdir"/usr/bin/scx_flatcg
+   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
+   install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
    install -Dm755 scx_pair "$pkgdir"/usr/bin/scx_pair
    install -Dm755 scx_qmap "$pkgdir"/usr/bin/scx_qmap
    install -Dm755 scx_rusty "$pkgdir"/usr/bin/scx_rusty
    install -Dm755 scx_simple "$pkgdir"/usr/bin/scx_simple
    install -Dm755 scx_userland "$pkgdir"/usr/bin/scx_userland
-   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
-   install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
 }
 
 pkgname=("$pkgbase" "$pkgbase-headers")

--- a/linux-cachyos-rt-bore/PKGBUILD
+++ b/linux-cachyos-rt-bore/PKGBUILD
@@ -851,6 +851,7 @@ _package-schedulers() {
    install -Dm755 scx_rusty "$pkgdir"/usr/bin/scx_rusty
    install -Dm755 scx_simple "$pkgdir"/usr/bin/scx_simple
    install -Dm755 scx_userland "$pkgdir"/usr/bin/scx_userland
+   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
    install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
 }
 

--- a/linux-cachyos-rt/PKGBUILD
+++ b/linux-cachyos-rt/PKGBUILD
@@ -846,13 +846,13 @@ _package-schedulers() {
 
    install -Dm755 scx_central "$pkgdir"/usr/bin/scx_central
    install -Dm755 scx_flatcg "$pkgdir"/usr/bin/scx_flatcg
+   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
+   install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
    install -Dm755 scx_pair "$pkgdir"/usr/bin/scx_pair
    install -Dm755 scx_qmap "$pkgdir"/usr/bin/scx_qmap
    install -Dm755 scx_rusty "$pkgdir"/usr/bin/scx_rusty
    install -Dm755 scx_simple "$pkgdir"/usr/bin/scx_simple
    install -Dm755 scx_userland "$pkgdir"/usr/bin/scx_userland
-   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
-   install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
 }
 
 pkgname=("$pkgbase" "$pkgbase-headers")

--- a/linux-cachyos-rt/PKGBUILD
+++ b/linux-cachyos-rt/PKGBUILD
@@ -851,6 +851,7 @@ _package-schedulers() {
    install -Dm755 scx_rusty "$pkgdir"/usr/bin/scx_rusty
    install -Dm755 scx_simple "$pkgdir"/usr/bin/scx_simple
    install -Dm755 scx_userland "$pkgdir"/usr/bin/scx_userland
+   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
    install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
 }
 

--- a/linux-cachyos-sched-ext/PKGBUILD
+++ b/linux-cachyos-sched-ext/PKGBUILD
@@ -846,13 +846,13 @@ _package-schedulers() {
 
    install -Dm755 scx_central "$pkgdir"/usr/bin/scx_central
    install -Dm755 scx_flatcg "$pkgdir"/usr/bin/scx_flatcg
+   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
+   install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
    install -Dm755 scx_pair "$pkgdir"/usr/bin/scx_pair
    install -Dm755 scx_qmap "$pkgdir"/usr/bin/scx_qmap
    install -Dm755 scx_rusty "$pkgdir"/usr/bin/scx_rusty
    install -Dm755 scx_simple "$pkgdir"/usr/bin/scx_simple
    install -Dm755 scx_userland "$pkgdir"/usr/bin/scx_userland
-   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
-   install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
 }
 
 pkgname=("$pkgbase" "$pkgbase-headers")

--- a/linux-cachyos-sched-ext/PKGBUILD
+++ b/linux-cachyos-sched-ext/PKGBUILD
@@ -851,6 +851,7 @@ _package-schedulers() {
    install -Dm755 scx_rusty "$pkgdir"/usr/bin/scx_rusty
    install -Dm755 scx_simple "$pkgdir"/usr/bin/scx_simple
    install -Dm755 scx_userland "$pkgdir"/usr/bin/scx_userland
+   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
    install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
 }
 

--- a/linux-cachyos-server/PKGBUILD
+++ b/linux-cachyos-server/PKGBUILD
@@ -846,13 +846,13 @@ _package-schedulers() {
 
    install -Dm755 scx_central "$pkgdir"/usr/bin/scx_central
    install -Dm755 scx_flatcg "$pkgdir"/usr/bin/scx_flatcg
+   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
+   install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
    install -Dm755 scx_pair "$pkgdir"/usr/bin/scx_pair
    install -Dm755 scx_qmap "$pkgdir"/usr/bin/scx_qmap
    install -Dm755 scx_rusty "$pkgdir"/usr/bin/scx_rusty
    install -Dm755 scx_simple "$pkgdir"/usr/bin/scx_simple
    install -Dm755 scx_userland "$pkgdir"/usr/bin/scx_userland
-   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
-   install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
 }
 
 pkgname=("$pkgbase" "$pkgbase-headers")

--- a/linux-cachyos-server/PKGBUILD
+++ b/linux-cachyos-server/PKGBUILD
@@ -851,6 +851,7 @@ _package-schedulers() {
    install -Dm755 scx_rusty "$pkgdir"/usr/bin/scx_rusty
    install -Dm755 scx_simple "$pkgdir"/usr/bin/scx_simple
    install -Dm755 scx_userland "$pkgdir"/usr/bin/scx_userland
+   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
    install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
 }
 

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -846,13 +846,13 @@ _package-schedulers() {
 
    install -Dm755 scx_central "$pkgdir"/usr/bin/scx_central
    install -Dm755 scx_flatcg "$pkgdir"/usr/bin/scx_flatcg
+   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
+   install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
    install -Dm755 scx_pair "$pkgdir"/usr/bin/scx_pair
    install -Dm755 scx_qmap "$pkgdir"/usr/bin/scx_qmap
    install -Dm755 scx_rusty "$pkgdir"/usr/bin/scx_rusty
    install -Dm755 scx_simple "$pkgdir"/usr/bin/scx_simple
    install -Dm755 scx_userland "$pkgdir"/usr/bin/scx_userland
-   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
-   install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
 }
 
 pkgname=("$pkgbase" "$pkgbase-headers")

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -851,6 +851,7 @@ _package-schedulers() {
    install -Dm755 scx_rusty "$pkgdir"/usr/bin/scx_rusty
    install -Dm755 scx_simple "$pkgdir"/usr/bin/scx_simple
    install -Dm755 scx_userland "$pkgdir"/usr/bin/scx_userland
+   install -Dm755 scx_layered "$pkgdir"/usr/bin/scx_layered
    install -Dm755 scx_nest "$pkgdir"/usr/bin/scx_nest
 }
 


### PR DESCRIPTION
If we will add [sched-ext-latest](https://github.com/CachyOS/kernel-patches/blob/master/6.6/sched/0001-sched-ext-latest.patch) to linux-cachyos, we just need to merge this pull request. 