### PR TITLE
Add fbdev=1 fix for NVIDIA module

### DIFF
--- a/linux-bore/PKGBUILD
+++ b/linux-bore/PKGBUILD
@@ -178,7 +178,7 @@ _stable=${_major}.${_minor}
 _srcname=linux-${_stable}
 #_srcname=linux-${_major}
 pkgdesc='Linux BORE scheduler Kernel by CachyOS with other patches and improvements'
-pkgrel=1
+pkgrel=2
 _kernver=$pkgver-$pkgrel
 arch=('x86_64' 'x86_64_v3')
 url="https://github.com/CachyOS/linux-cachyos"
@@ -223,6 +223,7 @@ fi
 # NVIDIA pre-build module support
 if [ -n "$_build_nvidia" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run")
+    source+=("nvidia-drm-hotplug-workqueue.nvpatch::$_patchsource/misc/nvidia/nvidia-drm-hotplug-workqueue.patch")
 fi
 
 ## ToDo: Adjust for new Scheduler Changes
@@ -640,6 +641,10 @@ prepare() {
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
+
+        # Temporary fix for fbdev=1
+        # https://forums.developer.nvidia.com/t/545-29-06-18-1-flip-event-timeout-error-on-startup-shutdown-and-sometimes-suspend-wayland-unusable/274788/21
+        patch -Np0 -i "${srcdir}/nvidia-drm-hotplug-workqueue.nvpatch" -d "${srcdir}/${_nv_pkg}"
     fi
 }
 

--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -178,7 +178,7 @@ _stable=${_major}.${_minor}
 _srcname=linux-${_stable}
 #_srcname=linux-${_major}
 pkgdesc='Linux BORE scheduler Kernel by CachyOS with other patches and improvements'
-pkgrel=1
+pkgrel=2
 _kernver=$pkgver-$pkgrel
 arch=('x86_64' 'x86_64_v3')
 url="https://github.com/CachyOS/linux-cachyos"
@@ -223,6 +223,7 @@ fi
 # NVIDIA pre-build module support
 if [ -n "$_build_nvidia" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run")
+    source+=("nvidia-drm-hotplug-workqueue.nvpatch::$_patchsource/misc/nvidia/nvidia-drm-hotplug-workqueue.patch")
 fi
 
 ## ToDo: Adjust for new Scheduler Changes
@@ -640,6 +641,10 @@ prepare() {
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
+
+        # Temporary fix for fbdev=1
+        # https://forums.developer.nvidia.com/t/545-29-06-18-1-flip-event-timeout-error-on-startup-shutdown-and-sometimes-suspend-wayland-unusable/274788/21
+        patch -Np0 -i "${srcdir}/nvidia-drm-hotplug-workqueue.nvpatch" -d "${srcdir}/${_nv_pkg}"
     fi
 }
 

--- a/linux-cachyos-eevdf/PKGBUILD
+++ b/linux-cachyos-eevdf/PKGBUILD
@@ -178,7 +178,7 @@ _stable=${_major}.${_minor}
 _srcname=linux-${_stable}
 #_srcname=linux-${_major}
 pkgdesc='Linux EEVDF scheduler Kernel by CachyOS with other patches and improvements'
-pkgrel=1
+pkgrel=2
 _kernver=$pkgver-$pkgrel
 arch=('x86_64' 'x86_64_v3')
 url="https://github.com/CachyOS/linux-cachyos"
@@ -223,6 +223,7 @@ fi
 # NVIDIA pre-build module support
 if [ -n "$_build_nvidia" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run")
+    source+=("nvidia-drm-hotplug-workqueue.nvpatch::$_patchsource/misc/nvidia/nvidia-drm-hotplug-workqueue.patch")
 fi
 
 ## ToDo: Adjust for new Scheduler Changes
@@ -640,6 +641,10 @@ prepare() {
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
+
+        # Temporary fix for fbdev=1
+        # https://forums.developer.nvidia.com/t/545-29-06-18-1-flip-event-timeout-error-on-startup-shutdown-and-sometimes-suspend-wayland-unusable/274788/21
+        patch -Np0 -i "${srcdir}/nvidia-drm-hotplug-workqueue.nvpatch" -d "${srcdir}/${_nv_pkg}"
     fi
 }
 

--- a/linux-cachyos-hardened/PKGBUILD
+++ b/linux-cachyos-hardened/PKGBUILD
@@ -178,7 +178,7 @@ _stable=${_major}.${_minor}
 _srcname=linux-${_stable}
 #_srcname=linux-${_major}
 pkgdesc='Linux hardenened BORE scheduler Kernel by CachyOS with other patches and improvements'
-pkgrel=2
+pkgrel=3
 _kernver=$pkgver-$pkgrel
 arch=('x86_64' 'x86_64_v3')
 url="https://github.com/CachyOS/linux-cachyos"
@@ -219,6 +219,7 @@ fi
 # NVIDIA pre-build module support
 if [ -n "$_build_nvidia" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run")
+    source+=("nvidia-drm-hotplug-workqueue.nvpatch::$_patchsource/misc/nvidia/nvidia-drm-hotplug-workqueue.patch")
 fi
 
 ## ToDo: Adjust for new Scheduler Changes
@@ -636,6 +637,10 @@ prepare() {
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
+
+        # Temporary fix for fbdev=1
+        # https://forums.developer.nvidia.com/t/545-29-06-18-1-flip-event-timeout-error-on-startup-shutdown-and-sometimes-suspend-wayland-unusable/274788/21
+        patch -Np0 -i "${srcdir}/nvidia-drm-hotplug-workqueue.nvpatch" -d "${srcdir}/${_nv_pkg}"
     fi
 }
 

--- a/linux-cachyos-lts/PKGBUILD
+++ b/linux-cachyos-lts/PKGBUILD
@@ -196,7 +196,7 @@ _stable=${_major}.${_minor}
 _srcname=linux-${_stable}
 #_srcname=linux-${_major}
 pkgdesc='Linux BORE scheduler Kernel by CachyOS with other patches and improvements'
-pkgrel=1
+pkgrel=2
 _kernver=$pkgver-$pkgrel
 arch=('x86_64' 'x86_64_v3')
 url="https://github.com/CachyOS/linux-cachyos"
@@ -238,6 +238,7 @@ fi
 # NVIDIA pre-build module support
 if [ -n "$_build_nvidia" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run")
+    source+=("nvidia-drm-hotplug-workqueue.nvpatch::$_patchsource/misc/nvidia/nvidia-drm-hotplug-workqueue.patch")
 fi
 
 case "$_cpusched" in
@@ -663,6 +664,10 @@ prepare() {
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
+
+        # Temporary fix for fbdev=1
+        # https://forums.developer.nvidia.com/t/545-29-06-18-1-flip-event-timeout-error-on-startup-shutdown-and-sometimes-suspend-wayland-unusable/274788/21
+        patch -Np0 -i "${srcdir}/nvidia-drm-hotplug-workqueue.nvpatch" -d "${srcdir}/${_nv_pkg}"
     fi
 }
 

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -175,7 +175,7 @@ _stable=${_major}-${_rcver}
 _srcname=linux-${_stable}
 #_srcname=linux-${_major}
 pkgdesc='Linux EEVDF-BORE scheduler Kernel by CachyOS and with some other patches and other improvements'
-pkgrel=1
+pkgrel=2
 _kernver=$pkgver-$pkgrel
 arch=('x86_64' 'x86_64_v3')
 url="https://github.com/CachyOS/linux-cachyos"
@@ -220,6 +220,7 @@ fi
 # NVIDIA pre-build module support
 if [ -n "$_build_nvidia" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run")
+    source+=("nvidia-drm-hotplug-workqueue.nvpatch::$_patchsource/misc/nvidia/nvidia-drm-hotplug-workqueue.patch")
 fi
 
 ## ToDo: Adjust for new Scheduler Changes
@@ -633,6 +634,10 @@ prepare() {
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
+
+        # Temporary fix for fbdev=1
+        # https://forums.developer.nvidia.com/t/545-29-06-18-1-flip-event-timeout-error-on-startup-shutdown-and-sometimes-suspend-wayland-unusable/274788/21
+        patch -Np0 -i "${srcdir}/nvidia-drm-hotplug-workqueue.nvpatch" -d "${srcdir}/${_nv_pkg}"
     fi
 }
 

--- a/linux-cachyos-rt-bore/PKGBUILD
+++ b/linux-cachyos-rt-bore/PKGBUILD
@@ -178,7 +178,7 @@ _stable=${_major}.${_minor}
 _srcname=linux-${_stable}
 #_srcname=linux-${_major}
 pkgdesc='Linux kernel with BORE-RT patches by CachyOS with other patches and improvements'
-pkgrel=5
+pkgrel=6
 _kernver=$pkgver-$pkgrel
 arch=('x86_64' 'x86_64_v3')
 url="https://github.com/CachyOS/linux-cachyos"
@@ -223,6 +223,7 @@ fi
 # NVIDIA pre-build module support
 if [ -n "$_build_nvidia" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run")
+    source+=("nvidia-drm-hotplug-workqueue.nvpatch::$_patchsource/misc/nvidia/nvidia-drm-hotplug-workqueue.patch")
 fi
 
 ## ToDo: Adjust for new Scheduler Changes
@@ -640,6 +641,10 @@ prepare() {
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
+
+        # Temporary fix for fbdev=1
+        # https://forums.developer.nvidia.com/t/545-29-06-18-1-flip-event-timeout-error-on-startup-shutdown-and-sometimes-suspend-wayland-unusable/274788/21
+        patch -Np0 -i "${srcdir}/nvidia-drm-hotplug-workqueue.nvpatch" -d "${srcdir}/${_nv_pkg}"
     fi
 }
 

--- a/linux-cachyos-rt/PKGBUILD
+++ b/linux-cachyos-rt/PKGBUILD
@@ -178,7 +178,7 @@ _stable=${_major}.${_minor}
 _srcname=linux-${_stable}
 #_srcname=linux-${_major}
 pkgdesc='Linux kernel with RT patches by CachyOS with other patches and improvements'
-pkgrel=1
+pkgrel=2
 _kernver=$pkgver-$pkgrel
 arch=('x86_64' 'x86_64_v3')
 url="https://github.com/CachyOS/linux-cachyos"
@@ -223,6 +223,7 @@ fi
 # NVIDIA pre-build module support
 if [ -n "$_build_nvidia" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run")
+    source+=("nvidia-drm-hotplug-workqueue.nvpatch::$_patchsource/misc/nvidia/nvidia-drm-hotplug-workqueue.patch")
 fi
 
 ## ToDo: Adjust for new Scheduler Changes
@@ -640,6 +641,10 @@ prepare() {
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
+
+        # Temporary fix for fbdev=1
+        # https://forums.developer.nvidia.com/t/545-29-06-18-1-flip-event-timeout-error-on-startup-shutdown-and-sometimes-suspend-wayland-unusable/274788/21
+        patch -Np0 -i "${srcdir}/nvidia-drm-hotplug-workqueue.nvpatch" -d "${srcdir}/${_nv_pkg}"
     fi
 }
 

--- a/linux-cachyos-sched-ext/PKGBUILD
+++ b/linux-cachyos-sched-ext/PKGBUILD
@@ -178,7 +178,7 @@ _stable=${_major}.${_minor}
 _srcname=linux-${_stable}
 #_srcname=linux-${_major}
 pkgdesc='Linux SCHED-EXT with BORE scheduler Kernel by CachyOS with other patches and improvements'
-pkgrel=1
+pkgrel=2
 _kernver=$pkgver-$pkgrel
 arch=('x86_64' 'x86_64_v3')
 url="https://github.com/CachyOS/linux-cachyos"
@@ -223,6 +223,7 @@ fi
 # NVIDIA pre-build module support
 if [ -n "$_build_nvidia" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run")
+    source+=("nvidia-drm-hotplug-workqueue.nvpatch::$_patchsource/misc/nvidia/nvidia-drm-hotplug-workqueue.patch")
 fi
 
 ## ToDo: Adjust for new Scheduler Changes
@@ -640,6 +641,10 @@ prepare() {
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
+
+        # Temporary fix for fbdev=1
+        # https://forums.developer.nvidia.com/t/545-29-06-18-1-flip-event-timeout-error-on-startup-shutdown-and-sometimes-suspend-wayland-unusable/274788/21
+        patch -Np0 -i "${srcdir}/nvidia-drm-hotplug-workqueue.nvpatch" -d "${srcdir}/${_nv_pkg}"
     fi
 }
 

--- a/linux-cachyos-server/PKGBUILD
+++ b/linux-cachyos-server/PKGBUILD
@@ -178,7 +178,7 @@ _stable=${_major}.${_minor}
 _srcname=linux-${_stable}
 #_srcname=linux-${_major}
 pkgdesc='Linux EEVDF scheduler Kernel by CachyOS targeted for Servers'
-pkgrel=1
+pkgrel=2
 _kernver=$pkgver-$pkgrel
 arch=('x86_64' 'x86_64_v3')
 url="https://github.com/CachyOS/linux-cachyos"
@@ -223,6 +223,7 @@ fi
 # NVIDIA pre-build module support
 if [ -n "$_build_nvidia" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run")
+    source+=("nvidia-drm-hotplug-workqueue.nvpatch::$_patchsource/misc/nvidia/nvidia-drm-hotplug-workqueue.patch")
 fi
 
 ## ToDo: Adjust for new Scheduler Changes
@@ -640,6 +641,10 @@ prepare() {
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
+
+        # Temporary fix for fbdev=1
+        # https://forums.developer.nvidia.com/t/545-29-06-18-1-flip-event-timeout-error-on-startup-shutdown-and-sometimes-suspend-wayland-unusable/274788/21
+        patch -Np0 -i "${srcdir}/nvidia-drm-hotplug-workqueue.nvpatch" -d "${srcdir}/${_nv_pkg}"
     fi
 }
 

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -178,7 +178,7 @@ _stable=${_major}.${_minor}
 _srcname=linux-${_stable}
 #_srcname=linux-${_major}
 pkgdesc='Linux EEVDF-BORE scheduler Kernel by CachyOS with other patches and improvements'
-pkgrel=1
+pkgrel=2
 _kernver=$pkgver-$pkgrel
 arch=('x86_64' 'x86_64_v3')
 url="https://github.com/CachyOS/linux-cachyos"
@@ -223,6 +223,7 @@ fi
 # NVIDIA pre-build module support
 if [ -n "$_build_nvidia" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run")
+    source+=("nvidia-drm-hotplug-workqueue.nvpatch::$_patchsource/misc/nvidia/nvidia-drm-hotplug-workqueue.patch")
 fi
 
 ## ToDo: Adjust for new Scheduler Changes
@@ -640,6 +641,10 @@ prepare() {
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
+
+        # Temporary fix for fbdev=1
+        # https://forums.developer.nvidia.com/t/545-29-06-18-1-flip-event-timeout-error-on-startup-shutdown-and-sometimes-suspend-wayland-unusable/274788/21
+        patch -Np0 -i "${srcdir}/nvidia-drm-hotplug-workqueue.nvpatch" -d "${srcdir}/${_nv_pkg}"
     fi
 }
 


### PR DESCRIPTION
Since we ship fbdev=1 by default in cachyos-settings, we need to apply this patch to fix system boot issues.

See: https://forums.developer.nvidia.com/t/545-29-06-18-1-flip-event-timeout-error-on-startup-shutdown-and-sometimes-suspend-wayland-unusable/274788/20