### PR TITLE
Fixed grammar in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Visit the [COPR page](https://copr.fedorainfracloud.org/coprs/bieszczaders/kerne
 
 ### NixOS
 
-Nyx does provide a precompiled CachyOS Kernel and a bunch of other interesting packages. This repository is maintained by [chaotic-aur](https://github.com/chaotic-cx)
+Nix does provide a precompiled CachyOS Kernel and a bunch of other interesting packages. This repository is maintained by [chaotic-aur](https://github.com/chaotic-cx)
 Just follow this [README](https://github.com/chaotic-cx/nyx#how-to-use-it)
 
 ## Support


### PR DESCRIPTION
The word Nix was displayed as Nyx in the README.md