### PR TITLE
Fix config saving when building inside tmpfs

### DIFF
--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -523,7 +523,8 @@ prepare() {
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
-    cat .config > "${srcdir}/../config-${pkgver}-${pkgrel}${pkgbase#linux}"
+    local basedir="$(dirname "$(readlink "${srcdir}/config")")"
+    cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"

--- a/linux-cachyos-deckify/PKGBUILD
+++ b/linux-cachyos-deckify/PKGBUILD
@@ -526,7 +526,8 @@ prepare() {
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
-    cat .config > "${srcdir}/../config-${pkgver}-${pkgrel}${pkgbase#linux}"
+    local basedir="$(dirname "$(readlink "${srcdir}/config")")"
+    cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"

--- a/linux-cachyos-echo/PKGBUILD
+++ b/linux-cachyos-echo/PKGBUILD
@@ -523,7 +523,8 @@ prepare() {
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
-    cat .config > "${srcdir}/../config-${pkgver}-${pkgrel}${pkgbase#linux}"
+    local basedir="$(dirname "$(readlink "${srcdir}/config")")"
+    cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"

--- a/linux-cachyos-eevdf/PKGBUILD
+++ b/linux-cachyos-eevdf/PKGBUILD
@@ -523,7 +523,8 @@ prepare() {
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
-    cat .config > "${srcdir}/../config-${pkgver}-${pkgrel}${pkgbase#linux}"
+    local basedir="$(dirname "$(readlink "${srcdir}/config")")"
+    cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"

--- a/linux-cachyos-hardened/PKGBUILD
+++ b/linux-cachyos-hardened/PKGBUILD
@@ -523,7 +523,8 @@ prepare() {
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
-    cat .config > "${srcdir}/../config-${pkgver}-${pkgrel}${pkgbase#linux}"
+    local basedir="$(dirname "$(readlink "${srcdir}/config")")"
+    cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"

--- a/linux-cachyos-lts/PKGBUILD
+++ b/linux-cachyos-lts/PKGBUILD
@@ -591,7 +591,8 @@ prepare() {
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
-    cat .config > "${srcdir}/../config-${pkgver}-${pkgrel}${pkgbase#linux}"
+    local basedir="$(dirname "$(readlink "${srcdir}/config")")"
+    cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -525,7 +525,8 @@ prepare() {
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
-    cat .config > "${srcdir}/../config-${pkgver}-${pkgrel}${pkgbase#linux}"
+    local basedir="$(dirname "$(readlink "${srcdir}/config")")"
+    cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"

--- a/linux-cachyos-rt-bore/PKGBUILD
+++ b/linux-cachyos-rt-bore/PKGBUILD
@@ -523,7 +523,8 @@ prepare() {
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
-    cat .config > "${srcdir}/../config-${pkgver}-${pkgrel}${pkgbase#linux}"
+    local basedir="$(dirname "$(readlink "${srcdir}/config")")"
+    cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"

--- a/linux-cachyos-sched-ext/PKGBUILD
+++ b/linux-cachyos-sched-ext/PKGBUILD
@@ -523,7 +523,8 @@ prepare() {
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
-    cat .config > "${srcdir}/../config-${pkgver}-${pkgrel}${pkgbase#linux}"
+    local basedir="$(dirname "$(readlink "${srcdir}/config")")"
+    cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"

--- a/linux-cachyos-server/PKGBUILD
+++ b/linux-cachyos-server/PKGBUILD
@@ -523,7 +523,8 @@ prepare() {
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
-    cat .config > "${srcdir}/../config-${pkgver}-${pkgrel}${pkgbase#linux}"
+    local basedir="$(dirname "$(readlink "${srcdir}/config")")"
+    cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -523,7 +523,8 @@ prepare() {
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
-    cat .config > "${srcdir}/../config-${pkgver}-${pkgrel}${pkgbase#linux}"
+    local basedir="$(dirname "$(readlink "${srcdir}/config")")"
+    cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
     if [ -n "$_build_nvidia" ]; then
         cd "${srcdir}"


### PR DESCRIPTION
When building inside tmpfs, ``$srcdir`` and ``$pkgdir``, their parent directory will not be the directory with PKGBUILD, but /tmp. So we need to read symlink of one of the files in ``$srcdir`` to figure out where the directory with PKGBUILD actually is.