### PR TITLE
linux-cachyos: Default to ThinLTO

### DIFF
--- a/linux-cachyos/.SRCINFO
+++ b/linux-cachyos/.SRCINFO
@@ -28,12 +28,15 @@ pkgbase = linux-cachyos
 	source = https://raw.githubusercontent.com/cachyos/kernel-patches/master/6.11/misc/dkms-clang.patch
 	source = https://raw.githubusercontent.com/cachyos/kernel-patches/master/6.11/sched/0001-sched-ext.patch
 	source = https://raw.githubusercontent.com/cachyos/kernel-patches/master/6.11/sched/0001-bore-cachy-ext.patch
+	source = linux-cachyos.install
 	b2sums = 5720e8dd0bed0247dcfe0bdbce17e36e67bff56811611ae1b04f048b77b6e60c2a48303db73c5a0d4a56c7125cdd695116c4dfd965bd7cb28aa932f427bb3e7d
 	b2sums = 92e635bb3553896146bea23e5e414853723be9843c94750bc6d4bc327a76925bedb2b3b4481f2816a4691d684e417eae0279c1a2019cb37e9e852914696695da
 	b2sums = b1e964389424d43c398a76e7cee16a643ac027722b91fe59022afacb19956db5856b2808ca0dd484f6d0dfc170482982678d7a9a00779d98cd62d5105200a667
 	b2sums = cdb2c8d3184c4f0c9c9d50cf78db2e5e4a56eac0162b5d2400277e98c0432fecb96a25c50ef99aae328524bb546c3941e5fb3141e59d4943796574d73cd83182
+	b2sums = c7294a689f70b2a44b0c4e9f00c61dbd59dd7063ecbe18655c4e7f12e21ed7c5bb4f5169f5aa8623b1c59de7b2667facb024913ecb9f4c650dabce4e8a7e5452
 	b2sums = 019217482184364a3582b567649af9ce9af3f0dc6f6620ea6868ebe011c6e646573e167a574b98515997f829732601f13e8f62e76c8571f05d499d2c96da8976
 	b2sums = 13a8f31ba15a007b504f769019530d43b8cb1ec612598940f539ccea842f66ad0981d033a69ef5283c87e4e68abc92ea377e18d0ce930afe441683ebc1f2c99b
+	b2sums = dbc8885359c814d785f3d2fd316fc3416e1a243ea9a49d2a1a2906c283388a67741f8724cda6897b59483de7bdb671e28fc8b13eb09dd15682a8edbd2389b459
 
 pkgname = linux-cachyos
 	pkgdesc = The Linux SCHED-EXT + BORE + Cachy Sauce Kernel by CachyOS with other patches and improvements kernel and modules

--- a/linux-cachyos/.SRCINFO
+++ b/linux-cachyos/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = linux-cachyos
 	pkgdesc = Linux SCHED-EXT + BORE + Cachy Sauce Kernel by CachyOS with other patches and improvements
 	pkgver = 6.11.2
-	pkgrel = 2
+	pkgrel = 4
 	url = https://github.com/CachyOS/linux-cachyos
 	arch = x86_64
 	license = GPL-2.0-only
@@ -15,6 +15,9 @@ pkgbase = linux-cachyos
 	makedepends = tar
 	makedepends = xz
 	makedepends = zstd
+	makedepends = clang
+	makedepends = llvm
+	makedepends = lld
 	options = !strip
 	options = !debug
 	options = !lto
@@ -22,6 +25,7 @@ pkgbase = linux-cachyos
 	source = config
 	source = auto-cpu-optimization.sh
 	source = https://raw.githubusercontent.com/cachyos/kernel-patches/master/6.11/all/0001-cachyos-base-all.patch
+	source = https://raw.githubusercontent.com/cachyos/kernel-patches/master/6.11/misc/dkms-clang.patch
 	source = https://raw.githubusercontent.com/cachyos/kernel-patches/master/6.11/sched/0001-sched-ext.patch
 	source = https://raw.githubusercontent.com/cachyos/kernel-patches/master/6.11/sched/0001-bore-cachy-ext.patch
 	b2sums = 5720e8dd0bed0247dcfe0bdbce17e36e67bff56811611ae1b04f048b77b6e60c2a48303db73c5a0d4a56c7125cdd695116c4dfd965bd7cb28aa932f427bb3e7d
@@ -45,8 +49,12 @@ pkgname = linux-cachyos
 	provides = WIREGUARD-MODULE
 	provides = KSMBD-MODULE
 	provides = UKSMD-BUILTIN
+	provides = linux-cachyos-lto=6.11.2-4
+	replaces = linux-cachyos-lto
 
 pkgname = linux-cachyos-headers
 	pkgdesc = Headers and scripts for building modules for the Linux SCHED-EXT + BORE + Cachy Sauce Kernel by CachyOS with other patches and improvements kernel
 	depends = pahole
 	depends = linux-cachyos
+	provides = linux-cachyos-lto-headers=6.11.2-4
+	replaces = linux-cachyos-lto-headers

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -243,7 +243,8 @@ fi
 case "$_cpusched" in
     cachyos) # CachyOS Scheduler (Sched-ext + BORE + Cachy Sauce)
         source+=("${_patchsource}/sched/0001-sched-ext.patch"
-                 "${_patchsource}/sched/0001-bore-cachy-ext.patch");;
+                 "${_patchsource}/sched/0001-bore-cachy-ext.patch"
+                 linux-cachyos.install);;
     bore) ## BORE Scheduler
         source+=("${_patchsource}/sched/0001-bore-cachy.patch");;
     bmq) ## Project C Scheduler
@@ -822,5 +823,7 @@ b2sums=('5720e8dd0bed0247dcfe0bdbce17e36e67bff56811611ae1b04f048b77b6e60c2a48303
         '92e635bb3553896146bea23e5e414853723be9843c94750bc6d4bc327a76925bedb2b3b4481f2816a4691d684e417eae0279c1a2019cb37e9e852914696695da'
         'b1e964389424d43c398a76e7cee16a643ac027722b91fe59022afacb19956db5856b2808ca0dd484f6d0dfc170482982678d7a9a00779d98cd62d5105200a667'
         'cdb2c8d3184c4f0c9c9d50cf78db2e5e4a56eac0162b5d2400277e98c0432fecb96a25c50ef99aae328524bb546c3941e5fb3141e59d4943796574d73cd83182'
+        'c7294a689f70b2a44b0c4e9f00c61dbd59dd7063ecbe18655c4e7f12e21ed7c5bb4f5169f5aa8623b1c59de7b2667facb024913ecb9f4c650dabce4e8a7e5452'
         '019217482184364a3582b567649af9ce9af3f0dc6f6620ea6868ebe011c6e646573e167a574b98515997f829732601f13e8f62e76c8571f05d499d2c96da8976'
-        '13a8f31ba15a007b504f769019530d43b8cb1ec612598940f539ccea842f66ad0981d033a69ef5283c87e4e68abc92ea377e18d0ce930afe441683ebc1f2c99b')
+        '13a8f31ba15a007b504f769019530d43b8cb1ec612598940f539ccea842f66ad0981d033a69ef5283c87e4e68abc92ea377e18d0ce930afe441683ebc1f2c99b'
+        'dbc8885359c814d785f3d2fd316fc3416e1a243ea9a49d2a1a2906c283388a67741f8724cda6897b59483de7bdb671e28fc8b13eb09dd15682a8edbd2389b459')

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -109,7 +109,7 @@ _use_auto_optimization=${_use_auto_optimization-y}
 # "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
 # "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
 # "none: disable LTO
-_use_llvm_lto=${_use_llvm_lto-none}
+_use_llvm_lto=${_use_llvm_lto-thin}
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
@@ -143,11 +143,11 @@ _build_nvidia_open=${_build_nvidia_open-}
 _build_debug=${_build_debug-}
 
 if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] && [ "$_use_lto_suffix" = "y"  ]; then
-    _pkgsuffix=cachyos-lto
+    _pkgsuffix=cachyos
     pkgbase="linux-$_pkgsuffix"
 
 elif [ -n "$_use_llvm_lto" ]  ||  [[ "$_use_lto_suffix" = "n" ]]; then
-    _pkgsuffix=cachyos
+    _pkgsuffix=cachyos-gcc
     pkgbase="linux-$_pkgsuffix"
 fi
 _major=6.11
@@ -161,7 +161,7 @@ _stable=${_major}.${_minor}
 _srcname=linux-${_stable}
 #_srcname=linux-${_major}
 pkgdesc='Linux SCHED-EXT + BORE + Cachy Sauce Kernel by CachyOS with other patches and improvements'
-pkgrel=2
+pkgrel=4
 _kernver="$pkgver-$pkgrel"
 _kernuname="${pkgver}-${_pkgsuffix}"
 arch=('x86_64')
@@ -595,6 +595,12 @@ _package() {
                 'uksmd: Userspace KSM helper daemon')
     provides=(VIRTUALBOX-GUEST-MODULES WIREGUARD-MODULE KSMBD-MODULE UKSMD-BUILTIN)
 
+    # Replace LTO kernel with the default kernel
+    if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]; then
+        provides+=(linux-cachyos-lto=$_kernver)
+        replaces=(linux-cachyos-lto)
+    fi
+
     cd "$_srcname"
 
     local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
@@ -618,6 +624,12 @@ _package() {
 _package-headers() {
     pkgdesc="Headers and scripts for building modules for the $pkgdesc kernel"
     depends=('pahole' "${pkgbase}")
+
+    # Replace LTO kernel with the default kernel
+    if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]; then
+        provides+=(linux-cachyos-lto-headers=$_kernver)
+        replaces=(linux-cachyos-lto-headers)
+    fi
 
     cd "${_srcname}"
     local builddir="$pkgdir/usr/lib/modules/$(<version)/build"
@@ -704,6 +716,12 @@ _package-dbg(){
     pkgdesc="Non-stripped vmlinux file for the $pkgdesc kernel"
     depends=("${pkgbase}-headers")
 
+    # Replace LTO kernel with the default kernel
+    if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]; then
+        provides+=(linux-cachyos-lto-dbg=$_kernver)
+        replaces=(linux-cachyos-lto-dbg)
+    fi
+
     cd "${_srcname}"
     mkdir -p "$pkgdir/usr/src/debug/${pkgbase}"
     install -Dt "$pkgdir/usr/src/debug/${pkgbase}" -m644 vmlinux
@@ -714,6 +732,12 @@ _package-zfs(){
     depends=('pahole' "${pkgbase}=${_kernver}")
     provides=('ZFS-MODULE')
     license=('CDDL')
+
+    # Replace LTO kernel with the default kernel
+    if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]; then
+        provides+=(linux-cachyos-lto-zfs=$_kernver)
+        replaces=(linux-cachyos-lto-zfs)
+    fi
 
     cd "$_srcname"
     local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
@@ -732,6 +756,12 @@ _package-nvidia(){
     conflicts=("$pkgbase-nvidia-open")
     license=('custom')
 
+    # Replace LTO kernel with the default kernel
+    if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]; then
+        provides+=(linux-cachyos-lto-nvidia=$_kernver)
+        replaces=(linux-cachyos-lto-nvidia)
+    fi
+
     cd "$_srcname"
     local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
 
@@ -748,6 +778,12 @@ _package-nvidia-open(){
     provides=('NVIDIA-MODULE')
     conflicts=("$pkgbase-nvidia")
     license=('MIT AND GPL-2.0-only')
+
+    # Replace LTO kernel with the default kernel
+    if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]; then
+        provides+=(linux-cachyos-lto-nvidia-open=$_kernver)
+        replaces=(linux-cachyos-lto-nvidia-open)
+    fi
 
     cd "$_srcname"
     local modulesdir="$pkgdir/usr/lib/modules/$(<version)"

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -139,6 +139,11 @@ _build_nvidia=${_build_nvidia-}
 # Use this only if you have Turing+ GPU
 _build_nvidia_open=${_build_nvidia_open-}
 
+_is_lto_kernel() {
+    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]
+    return $?
+}
+
 # Build a debug package with non-stripped vmlinux
 _build_debug=${_build_debug-}
 
@@ -192,7 +197,7 @@ source=(
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
-if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]; then
+if _is_lto_kernel; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(
@@ -596,7 +601,7 @@ _package() {
     provides=(VIRTUALBOX-GUEST-MODULES WIREGUARD-MODULE KSMBD-MODULE UKSMD-BUILTIN)
 
     # Replace LTO kernel with the default kernel
-    if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]; then
+    if _is_lto_kernel; then
         provides+=(linux-cachyos-lto=$_kernver)
         replaces=(linux-cachyos-lto)
     fi
@@ -626,7 +631,7 @@ _package-headers() {
     depends=('pahole' "${pkgbase}")
 
     # Replace LTO kernel with the default kernel
-    if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]; then
+    if _is_lto_kernel; then
         provides+=(linux-cachyos-lto-headers=$_kernver)
         replaces=(linux-cachyos-lto-headers)
     fi
@@ -717,7 +722,7 @@ _package-dbg(){
     depends=("${pkgbase}-headers")
 
     # Replace LTO kernel with the default kernel
-    if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]; then
+    if _is_lto_kernel; then
         provides+=(linux-cachyos-lto-dbg=$_kernver)
         replaces=(linux-cachyos-lto-dbg)
     fi
@@ -734,7 +739,7 @@ _package-zfs(){
     license=('CDDL')
 
     # Replace LTO kernel with the default kernel
-    if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]; then
+    if _is_lto_kernel; then
         provides+=(linux-cachyos-lto-zfs=$_kernver)
         replaces=(linux-cachyos-lto-zfs)
     fi
@@ -757,7 +762,7 @@ _package-nvidia(){
     license=('custom')
 
     # Replace LTO kernel with the default kernel
-    if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]; then
+    if _is_lto_kernel; then
         provides+=(linux-cachyos-lto-nvidia=$_kernver)
         replaces=(linux-cachyos-lto-nvidia)
     fi
@@ -780,7 +785,7 @@ _package-nvidia-open(){
     license=('MIT AND GPL-2.0-only')
 
     # Replace LTO kernel with the default kernel
-    if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]; then
+    if _is_lto_kernel; then
         provides+=(linux-cachyos-lto-nvidia-open=$_kernver)
         replaces=(linux-cachyos-lto-nvidia-open)
     fi

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -112,11 +112,14 @@ _use_auto_optimization=${_use_auto_optimization-y}
 _use_llvm_lto=${_use_llvm_lto-thin}
 
 # Use suffix -lto only when requested by the user
-# Enabled by default.
 # y - enable -lto suffix
 # n - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-_use_lto_suffix=${_use_lto_suffix-y}
+_use_lto_suffix=${_use_lto_suffix-}
+
+# Use suffix -gcc when requested by the user
+# Enabled by default to show the difference between LTO kernels and GCC kernels
+_use_gcc_suffix=${_use_gcc_suffix-y}
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
@@ -148,13 +151,14 @@ _is_lto_kernel() {
 _build_debug=${_build_debug-}
 
 if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] && [ "$_use_lto_suffix" = "y"  ]; then
-    _pkgsuffix=cachyos
-    pkgbase="linux-$_pkgsuffix"
-
-elif [ -n "$_use_llvm_lto" ]  ||  [[ "$_use_lto_suffix" = "n" ]]; then
+    _pkgsuffix=cachyos-lto
+elif [ "$_use_llvm_lto" = "none" ]  && [ -z "_use_kcfi" ] && [ "$_use_gcc_suffix" = "y" ]; then
     _pkgsuffix=cachyos-gcc
-    pkgbase="linux-$_pkgsuffix"
+else
+    _pkgsuffix=cachyos
 fi
+
+pkgbase="linux-$_pkgsuffix"
 _major=6.11
 _minor=2
 #_minorc=$((_minor+1))

--- a/linux-cachyos/linux-cachyos.install
+++ b/linux-cachyos/linux-cachyos.install
@@ -1,0 +1,11 @@
+post_install() {
+    cat << EOF
+Following this update, the default `linux-cachyos` kernel has defaulted to be built with clang + ThinLTO.
+This means that `linux-cachyos-lto` will be obsolete and will be replaced with `linux-cachyos`.
+The GCC-built kernel will now be packaged under `linux-cachyos-gcc`. Install that package if you wish to continue using that kernel.
+EOF
+}
+
+post_upgrade() {
+    post_install
+}

--- a/script-v3-v4.sh
+++ b/script-v3-v4.sh
@@ -2,12 +2,14 @@
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_auto_optimization-y/_use_auto_optimization-/" {}
 ## Enable ZFS
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_zfs-/_build_zfs-y/" {}
-## Enable Generic v3 
+## Enable Generic v3
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_processor_opt-/_processor_opt-GENERIC_V3/" {}
 ## Enable NVIDIA module
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia-/_build_nvidia-y/" {}
 ## Enable Open NVIDIA module
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia_open-/_build_nvidia_open-y/" {}
+## Disable clang-LTO
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_llvm_lto-thin/_use_llvm_lto-none/" {}
 
 ## GCC v3 Kernel
 


### PR DESCRIPTION
Second and final part of #286. The default kernel will now use clang + ThinLTO as its default configuration.

To accomodate this change, I have added a conditional statement for each `_package` function to replace existing LTO kernels that are already installed to smoothen the transition. Furthermore, I have modified the build script to ensure that all PKGBUILDs will build with GCC first before building the LTO kernels.

We should do a staged rollout for this change to cachyos-testing-v3 -> cachyos-znver4 -> all repos to ensure that everything works correctly (most notably dkms modules, even though they compile successfully, we should ensure complete functionality)

Closes #286 