### PR TITLE
linux-cachyos-autofdo: Add clang check when $_autofdo* is enabled

### DIFF
--- a/linux-cachyos-autofdo/PKGBUILD
+++ b/linux-cachyos-autofdo/PKGBUILD
@@ -166,7 +166,7 @@ _autofdo_profile_name=${_autofdo_profile_name-"perf.afdo"}
 
 # ATTENTION: Do not modify after this line
 _is_clang_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]
+    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ] || [ -n "$_autofdo" ] || [ -n "$_autofdo_use" ]
     return $?
 }
 

--- a/linux-cachyos-autofdo/PKGBUILD
+++ b/linux-cachyos-autofdo/PKGBUILD
@@ -165,7 +165,7 @@ _autofdo_profile_name=${_autofdo_profile_name-"perf.afdo"}
 
 
 # ATTENTION: Do not modify after this line
-_is_lto_kernel() {
+_is_clang_kernel() {
     [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]
     return $?
 }
@@ -215,7 +215,7 @@ source=(
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
-if _is_lto_kernel; then
+if _is_clang_kernel; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -148,7 +148,7 @@ _build_debug=${_build_debug-}
 
 
 # ATTENTION: Do not modify after this line
-_is_lto_kernel() {
+_is_clang_kernel() {
     [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]
     return $?
 }
@@ -204,7 +204,7 @@ source=(
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
-if _is_lto_kernel; then
+if _is_clang_kernel; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(


### PR DESCRIPTION
This enables the possibility of using AutoFDO without explicitly enabling Thin/Full LTO.

