### PR TITLE
linux-cachyos{,-rc}: Conditionally add clang-llvm to headers dependencies

### DIFF
--- a/linux-cachyos-bmq/PKGBUILD
+++ b/linux-cachyos-bmq/PKGBUILD
@@ -143,14 +143,14 @@ _build_nvidia_open=${_build_nvidia_open-}
 _build_debug=${_build_debug-}
 
 # ATTENTION: Do not modify after this line
-_is_clang_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]
+_is_lto_kernel() {
+    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]]
     return $?
 }
 
-if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] && [ "$_use_lto_suffix" = "y"  ]; then
+if _is_lto_kernel && [ "$_use_lto_suffix" = "y"  ]; then
     _pkgsuffix="cachyos-${_cpusched}-lto"
-elif [ "$_use_llvm_lto" = "none" ]  && [ -z "$_use_kcfi" ] && [ "$_use_gcc_suffix" = "y" ]; then
+elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "y" ]; then
     _pkgsuffix="cachyos-${_cpusched}-gcc"
 else
     _pkgsuffix="cachyos-${_cpusched}"
@@ -199,7 +199,7 @@ source=(
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
-if _is_clang_kernel; then
+if _is_lto_kernel; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(

--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -143,14 +143,14 @@ _build_nvidia_open=${_build_nvidia_open-}
 _build_debug=${_build_debug-}
 
 # ATTENTION: Do not modify after this line
-_is_clang_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]
+_is_lto_kernel() {
+    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]]
     return $?
 }
 
-if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] && [ "$_use_lto_suffix" = "y"  ]; then
+if _is_lto_kernel && [ "$_use_lto_suffix" = "y"  ]; then
     _pkgsuffix="cachyos-${_cpusched}-lto"
-elif [ "$_use_llvm_lto" = "none" ]  && [ -z "$_use_kcfi" ] && [ "$_use_gcc_suffix" = "y" ]; then
+elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "y" ]; then
     _pkgsuffix="cachyos-${_cpusched}-gcc"
 else
     _pkgsuffix="cachyos-${_cpusched}"
@@ -199,7 +199,7 @@ source=(
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
-if _is_clang_kernel; then
+if _is_lto_kernel; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(

--- a/linux-cachyos-deckify/PKGBUILD
+++ b/linux-cachyos-deckify/PKGBUILD
@@ -142,14 +142,14 @@ _build_nvidia_open=${_build_nvidia_open-}
 _build_debug=${_build_debug-}
 
 # ATTENTION: Do not modify after this line
-_is_clang_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]
+_is_lto_kernel() {
+    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]]
     return $?
 }
 
-if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] && [ "$_use_lto_suffix" = "y"  ]; then
+if _is_lto_kernel && [ "$_use_lto_suffix" = "y"  ]; then
     _pkgsuffix="cachyos-deckify-lto"
-elif [ "$_use_llvm_lto" = "none" ]  && [ -z "$_use_kcfi" ] && [ "$_use_gcc_suffix" = "y" ]; then
+elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "y" ]; then
     _pkgsuffix="cachyos-deckify-gcc"
 else
     _pkgsuffix="cachyos-deckify"
@@ -201,7 +201,7 @@ source=(
     "${_patchsource}/misc/0001-handheld.patch")
 
 # LLVM makedepends
-if _is_clang_kernel; then
+if _is_lto_kernel; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(

--- a/linux-cachyos-eevdf/PKGBUILD
+++ b/linux-cachyos-eevdf/PKGBUILD
@@ -143,14 +143,14 @@ _build_nvidia_open=${_build_nvidia_open-}
 _build_debug=${_build_debug-}
 
 # ATTENTION: Do not modify after this line
-_is_clang_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]
+_is_lto_kernel() {
+    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]]
     return $?
 }
 
-if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] && [ "$_use_lto_suffix" = "y"  ]; then
+if _is_lto_kernel && [ "$_use_lto_suffix" = "y"  ]; then
     _pkgsuffix="cachyos-${_cpusched}-lto"
-elif [ "$_use_llvm_lto" = "none" ]  && [ -z "$_use_kcfi" ] && [ "$_use_gcc_suffix" = "y" ]; then
+elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "y" ]; then
     _pkgsuffix="cachyos-${_cpusched}-gcc"
 else
     _pkgsuffix="cachyos-${_cpusched}"
@@ -199,7 +199,7 @@ source=(
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
-if _is_clang_kernel; then
+if _is_lto_kernel; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(

--- a/linux-cachyos-rc/.SRCINFO
+++ b/linux-cachyos-rc/.SRCINFO
@@ -53,3 +53,6 @@ pkgname = linux-cachyos-rc-headers
 	pkgdesc = Headers and scripts for building modules for the Linux BORE + LTO + Cachy Sauce Kernel by CachyOS with other patches and improvements - Release Candidate kernel
 	depends = pahole
 	depends = linux-cachyos-rc
+	depends = clang
+	depends = llvm
+	depends = lld

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -640,6 +640,10 @@ _package-headers() {
     pkgdesc="Headers and scripts for building modules for the $pkgdesc kernel"
     depends=('pahole' "${pkgbase}")
 
+    if _is_lto_kernel; then
+        depends+=(clang llvm lld)
+    fi
+
     cd "${_srcname}"
     local builddir="$pkgdir/usr/lib/modules/$(<version)/build"
 

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -156,14 +156,14 @@ _autofdo_profile_name=${_autofdo_profile_name-}
 
 
 # ATTENTION: Do not modify after this line
-_is_clang_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ] || [ -n "$_autofdo" ]
+_is_lto_kernel() {
+    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]]
     return $?
 }
 
-if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] && [ "$_use_lto_suffix" = "y"  ]; then
+if _is_lto_kernel && [ "$_use_lto_suffix" = "y"  ]; then
     _pkgsuffix="cachyos-rc-lto"
-elif [ "$_use_llvm_lto" = "none" ]  && [ -z "$_use_kcfi" ] && [ "$_use_gcc_suffix" = "y" ]; then
+elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "y" ]; then
     _pkgsuffix="cachyos-rc-gcc"
 else
     _pkgsuffix="cachyos-rc"
@@ -212,7 +212,7 @@ source=(
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
-if _is_clang_kernel; then
+if _is_lto_kernel; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(

--- a/linux-cachyos-rt-bore/PKGBUILD
+++ b/linux-cachyos-rt-bore/PKGBUILD
@@ -143,14 +143,14 @@ _build_nvidia_open=${_build_nvidia_open-}
 _build_debug=${_build_debug-}
 
 # ATTENTION: Do not modify after this line
-_is_clang_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]
+_is_lto_kernel() {
+    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]]
     return $?
 }
 
-if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] && [ "$_use_lto_suffix" = "y"  ]; then
+if _is_lto_kernel && [ "$_use_lto_suffix" = "y"  ]; then
     _pkgsuffix="cachyos-${_cpusched}-lto"
-elif [ "$_use_llvm_lto" = "none" ]  && [ -z "$_use_kcfi" ] && [ "$_use_gcc_suffix" = "y" ]; then
+elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "y" ]; then
     _pkgsuffix="cachyos-${_cpusched}-gcc"
 else
     _pkgsuffix="cachyos-${_cpusched}"
@@ -199,7 +199,7 @@ source=(
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
-if _is_clang_kernel; then
+if _is_lto_kernel; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(

--- a/linux-cachyos-server/PKGBUILD
+++ b/linux-cachyos-server/PKGBUILD
@@ -143,14 +143,14 @@ _build_nvidia_open=${_build_nvidia_open-}
 _build_debug=${_build_debug-}
 
 # ATTENTION: Do not modify after this line
-_is_clang_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]
+_is_lto_kernel() {
+    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]]
     return $?
 }
 
-if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] && [ "$_use_lto_suffix" = "y"  ]; then
+if _is_lto_kernel && [ "$_use_lto_suffix" = "y"  ]; then
     _pkgsuffix="cachyos-server-lto"
-elif [ "$_use_llvm_lto" = "none" ]  && [ -z "$_use_kcfi" ] && [ "$_use_gcc_suffix" = "y" ]; then
+elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "y" ]; then
     _pkgsuffix="cachyos-server-gcc"
 else
     _pkgsuffix="cachyos-server"
@@ -199,7 +199,7 @@ source=(
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
-if _is_clang_kernel; then
+if _is_lto_kernel; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(

--- a/linux-cachyos/.SRCINFO
+++ b/linux-cachyos/.SRCINFO
@@ -53,3 +53,6 @@ pkgname = linux-cachyos-headers
 	pkgdesc = Headers and scripts for building modules for the Linux BORE + LTO + AutoFDO Cachy Sauce Kernel by CachyOS with other patches and improvements. kernel
 	depends = pahole
 	depends = linux-cachyos
+	depends = clang
+	depends = llvm
+	depends = lld

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -636,6 +636,10 @@ _package-headers() {
     pkgdesc="Headers and scripts for building modules for the $pkgdesc kernel"
     depends=('pahole' "${pkgbase}")
 
+    if _is_lto_kernel; then
+        depends+=(clang llvm lld)
+    fi
+
     cd "${_srcname}"
     local builddir="$pkgdir/usr/lib/modules/$(<version)/build"
 

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -156,14 +156,14 @@ _autofdo_profile_name=${_autofdo_profile_name-}
 
 
 # ATTENTION: Do not modify after this line
-_is_clang_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ] || [ -n "$_autofdo" ]
+_is_lto_kernel() {
+    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]]
     return $?
 }
 
-if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] && [ "$_use_lto_suffix" = "y"  ]; then
+if _is_lto_kernel && [ "$_use_lto_suffix" = "y"  ]; then
     _pkgsuffix=cachyos-lto
-elif [ "$_use_llvm_lto" = "none" ]  && [ -z "$_use_kcfi" ] && [ "$_use_gcc_suffix" = "y" ]; then
+elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "y" ]; then
     _pkgsuffix=cachyos-gcc
 else
     _pkgsuffix=cachyos
@@ -212,7 +212,7 @@ source=(
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
-if _is_clang_kernel; then
+if _is_lto_kernel; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(


### PR DESCRIPTION
Since we are compiling the default kernel with clang rather than GCC, we need to pull clang as a dependency
to ensure functionality with building out-of-tree kernel modules. For CachyOS users, this is already seamless
because our dkms package is dependent on clang, but AUR users and non-CachyOS users can suffer from this.

Note that this generates a bogus .SRCINFO when !_is_clang_kernel() but that doesn't matter for 100% of usecases
because it's default True (unless some third party repository defaults to GCC in which case they should fix it
on their own).

Depends on #354