### PR TITLE
fix: Account for autofdo in build script and pkgsuffix conditions

### DIFF
--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -163,7 +163,7 @@ _is_clang_kernel() {
 
 if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] && [ "$_use_lto_suffix" = "y"  ]; then
     _pkgsuffix="cachyos-rc-lto"
-elif [ "$_use_llvm_lto" = "none" ]  && [ -z "$_use_kcfi" ] && [ "$_use_gcc_suffix" = "y" ]; then
+elif [ "$_use_llvm_lto" = "none" ]  && [ -z "$_use_kcfi" ] && [ "$_use_gcc_suffix" = "y" ] && [ -z "$_autofdo" ]; then
     _pkgsuffix="cachyos-rc-gcc"
 else
     _pkgsuffix="cachyos-rc"

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -163,7 +163,7 @@ _is_clang_kernel() {
 
 if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] && [ "$_use_lto_suffix" = "y"  ]; then
     _pkgsuffix=cachyos-lto
-elif [ "$_use_llvm_lto" = "none" ]  && [ -z "$_use_kcfi" ] && [ "$_use_gcc_suffix" = "y" ]; then
+elif [ "$_use_llvm_lto" = "none" ]  && [ -z "$_use_kcfi" ] && [ "$_use_gcc_suffix" = "y" ] && [ -z "$_autofdo" ]; then
     _pkgsuffix=cachyos-gcc
 else
     _pkgsuffix=cachyos

--- a/script-v3-v4.sh
+++ b/script-v3-v4.sh
@@ -10,6 +10,8 @@ find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia-/_build_nvidia-y/"
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia_open-/_build_nvidia_open-y/" {}
 ## Disable clang-LTO
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_llvm_lto-thin/_use_llvm_lto-none/" {}
+## Force autofdo off to ensure that kernels are being compiled with GCC
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_autofdo-y/_autofdo-/" {}
 
 ## GCC v3 Kernel
 
@@ -26,6 +28,7 @@ done
 
 ## LLVM ThinLTO v3 Kernel
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_llvm_lto-none/_use_llvm_lto-thin/" {}
+find linux-cachyos linux-cachyos-rc -name "PKGBUILD" | xargs -I {} sed -i "s/_autofdo-/_autofdo-y/" {}
 
 files=$(find . -name "PKGBUILD")
 
@@ -47,6 +50,7 @@ RUST_LOG=trace repo-manage-util -p cachyos-v3 update
 ## GCC v4 Kernel
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_llvm_lto-thin/_use_llvm_lto-none/" {}
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_processor_opt-GENERIC_V3/_processor_opt-GENERIC_V4/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_autofdo-y/_autofdo-/" {}
 
 files=$(find . -name "PKGBUILD")
 
@@ -61,6 +65,7 @@ done
 
 ## LLVM ThinLTO v4 Kernel
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_llvm_lto-none/_use_llvm_lto-thin/" {}
+find linux-cachyos linux-cachyos-rc -name "PKGBUILD" | xargs -I {} sed -i "s/_autofdo-/_autofdo-y/" {}
 
 files=$(find . -name "PKGBUILD")
 

--- a/script.sh
+++ b/script.sh
@@ -6,6 +6,8 @@ find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_zfs-/_build_zfs-y/" {}
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia-/_build_nvidia-y/" {}
 ## Enable Open NVIDIA module
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia_open-/_build_nvidia_open-y/" {}
+## Force autofdo off to ensure that kernels are being compiled with GCC
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_autofdo-y/_autofdo-/" {}
 
 files=$(find . -name "PKGBUILD")
 


### PR DESCRIPTION
In the PKGBUILD, we have a check whenever $autofdo is a non-zero string, it will build with clang. This breaks
the workflow of the script when building with GCC. It's not that obvious that it's broken because $pkgsuffix is
also broken. This is also fixed by adding a check for it.

We can fix this by forcing $autofdo off during GCC compilations and flipping it back on again when compiling with
ThinLTO.