### PR TITLE
linux-cachyos{,-rc}: Check for LTO when sourcing and passing build flags for autofdo

### DIFF
--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -252,7 +252,7 @@ if [ -n "$_build_nvidia_open" ]; then
 fi
 
 # Use generated AutoFDO Profile
-if [ -n "$_autofdo" ] && [ -n "$_autofdo_profile_name" ]; then
+if _is_lto_kernel && [ -n "$_autofdo" ] && [ -n "$_autofdo_profile_name" ]; then
     if [ -e "$_autofdo_profile_name" ]; then
         source+=("$_autofdo_profile_name")
     else
@@ -480,7 +480,7 @@ prepare() {
         scripts/config -e AUTOFDO_CLANG
     fi
 
-    if [ -n "$_autofdo" ] && [ -n "$_autofdo_profile_name" ]; then
+    if _is_lto_kernel && [ -n "$_autofdo" ] && [ -n "$_autofdo_profile_name" ]; then
         echo "AutoFDO profile has been found..."
         BUILD_FLAGS+=(CLANG_AUTOFDO_PROFILE="${srcdir}/${_autofdo_profile_name}")
     fi

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -250,7 +250,7 @@ if [ -n "$_build_nvidia_open" ]; then
 fi
 
 # Use generated AutoFDO Profile
-if [ -n "$_autofdo" ] && [ -n "$_autofdo_profile_name" ]; then
+if _is_lto_kernel && [ -n "$_autofdo" ] && [ -n "$_autofdo_profile_name" ]; then
     if [ -e "$_autofdo_profile_name" ]; then
         source+=("$_autofdo_profile_name")
     else
@@ -479,7 +479,7 @@ prepare() {
         scripts/config -e AUTOFDO_CLANG
     fi
 
-    if [ -n "$_autofdo" ] && [ -n "$_autofdo_profile_name" ]; then
+    if _is_lto_kernel && [ -n "$_autofdo" ] && [ -n "$_autofdo_profile_name" ]; then
         echo "AutoFDO profile has been found..."
         BUILD_FLAGS+=(CLANG_AUTOFDO_PROFILE="${srcdir}/${_autofdo_profile_name}")
     fi


### PR DESCRIPTION
While in theory this shouldn't cause any compilation issues due to different compiler being used, we should still check for this to remove unnecessary build flags and files in the source array.