### PR TITLE
Add support for Propeller Optimization

### DIFF
--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -154,6 +154,18 @@ _autofdo=${_autofdo-}
 # Name for the AutoFDO profile
 _autofdo_profile_name=${_autofdo_profile_name-}
 
+# Propeller should be applied, after the kernel is optimized with AutoFDO
+# Workflow:
+# 1. Proceed with above AutoFDO Optimization, but enable at the final compilation also _propeller
+# 2. Boot into the AutoFDO Kernel and profile it
+# 3. Convert the profile into the propeller profile, example:
+# create_llvm_prof --binary=/usr/src/debug/linux-cachyos-rc/vmlinux --profile=propeller.data --format=propeller --propeller_output_module_name --out=/home/ptr1337/bench/propeller_cc_profile.txt --propeller_symorder=/home/ptr1337/bench/propeller_ld_profile.txt
+# 4. Place the propeller_cc_profile.txt and propeller_ld_profile.txt into the sourcedir
+# 5. Enable _propeller_prefix
+_propeller=${_propeller-}
+
+# Enable for final compilation with name "propeller"
+_propeller_prefix=${_propeller_prefix-propeller}
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
@@ -258,6 +270,15 @@ if [ -n "$_autofdo" ] && [ -n "$_autofdo_profile_name" ]; then
         source+=("$_autofdo_profile_name")
     else
         _die "Failed to find file ${_autofdo_profile_name}"
+    fi
+fi
+
+# Use generated Propeller Profile
+if [ -n "$_propeller" ] && [ -n "$_propeller_prefix" ]; then
+    if [ -e "$_autofdo_profile_name" ]; then
+        source+=("$_propeller_prefix")
+    else
+        _die "Failed to find file ${_propeller_prefix}"
     fi
 fi
 
@@ -484,6 +505,12 @@ prepare() {
     if [ -n "$_autofdo" ] && [ -n "$_autofdo_profile_name" ]; then
         echo "AutoFDO profile has been found..."
         BUILD_FLAGS+=(CLANG_AUTOFDO_PROFILE="${srcdir}/${_autofdo_profile_name}")
+    fi
+
+    # Propeller Optimization
+    if [ -n "$_propeller" ] && [ -n "$_propeller_prefix" ]; then
+        echo "Propeller profile has been found..."
+        BUILD_FLAGS+=(CLANG_PROPELLER_PROFILE_PREFIX="${srcdir}/_propeller_prefix")
     fi
 
     echo "Enable USER_NS_UNPRIVILEGED"

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -508,6 +508,9 @@ prepare() {
     fi
 
     # Propeller Optimization
+    if [ -n "$_propeller" ]; then
+        scripts/config -e PROPELLER_CLANG
+    fi
     if [ -n "$_propeller" ] && [ -n "$_propeller_prefix" ]; then
         echo "Propeller profile has been found..."
         BUILD_FLAGS+=(CLANG_PROPELLER_PROFILE_PREFIX="${srcdir}/_propeller_prefix")


### PR DESCRIPTION
This adds support to the PKGBUILD for the Propeller Optimization.
Propeller currently depends on LLVM 19, which should arrive soon.

The workflow would be:
1. Default AutoFDO workflow and enable at the last compilation _propeller to be enabled, so that the config gets enabled
2. Boot into the AutoFDO Kernel with Propeller enabled and profile it
3. Convert the profile with following command and replace prefix with the wanted prefix: create_llvm_prof --binary=/usr/src/debug/linux-cachyos-rc/vmlinux --profile=propeller.data --format=propeller --propeller_output_module_name --out=/home/ptr1337/bench/$prefix_cc_profile.txt --propeller_symorder=/home/ptr1337/bench/$prefix_ld_profile.txt
4. Set the selected prefix in the _propeller_prefix 
5. Compile the final kernel

I did not do enhanced benchmarks, but generally AutoFDO + Propeller should provide an 10% throughput benefit according google. We might want to experiment, which profile workload is suited, and how long/extended the profiling should be


Signed-off-by: Peter Jung <admin@ptr1337.dev>