### PR TITLE
Refactor setting of default values

### DIFF
--- a/linux-cachyos-bmq/PKGBUILD
+++ b/linux-cachyos-bmq/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-_cachy_config=${_cachy_config-y}
+: "${_cachy_config:=y}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -20,25 +20,25 @@ _cachy_config=${_cachy_config-y}
 # 'eevdf' - select 'EEVDF Scheduler'
 # 'rt' - select EEVDF, but includes a series of realtime patches
 # 'rt-bore' - select Burst-Oriented Response Enhancer, but includes a series of realtime patches
-_cpusched=${_cpusched-bmq}
+: "${_cpusched:=bmq}"
 
 ### Tweak kernel options prior to a build via nconfig
-_makenconfig=${_makenconfig-}
+: "${_makenconfig:=}"
 
 ### Tweak kernel options prior to a build via menuconfig
-_makemenuconfig=${_makemenuconfig-}
+: "${_makemenuconfig:=}"
 
 ### Tweak kernel options prior to a build via xconfig
-_makexconfig=${_makexconfig-}
+: "${_makexconfig:=}"
 
 ### Tweak kernel options prior to a build via gconfig
-_makegconfig=${_makegconfig-}
+: "${_makegconfig:=}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-_NUMAdisable=${_NUMAdisable-}
+: "${_NUMAdisable:=}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,36 +48,36 @@ _NUMAdisable=${_NUMAdisable-}
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-_localmodcfg=${_localmodcfg-}
+: "${_localmodcfg:=}"
 
 # Path to the list of used modules
-_localmodcfg_path=${_localmodcfg_path-"$HOME/.config/modprobed.db"}
+: "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
 
 # Use the current kernel's .config file
 # Enabling this option will use the .config of the RUNNING kernel rather than
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-_use_current=${_use_current-}
+: "${_use_current:=}"
 
 ### Enable KBUILD_CFLAGS -O3
-_cc_harder=${_cc_harder-y}
+: "${_cc_harder:=y}"
 
 ### Set performance governor as default
-_per_gov=${_per_gov-}
+: "${_per_gov:=}"
 
 ### Enable TCP_CONG_BBR3
-_tcp_bbr3=${_tcp_bbr3-}
+: "${_tcp_bbr3:=}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
-_HZ_ticks=${_HZ_ticks-1000}
+: "${_HZ_ticks:=1000}"
 
 ## Choose between perodic, idle or full
 ### Full tickless can give higher performances in various cases but, depending on hardware, lower consistency.
-_tickrate=${_tickrate-full}
+: "${_tickrate:=full}"
 
 ## Choose between full(low-latency), voluntary or server
-_preempt=${_preempt-full}
+: "${_preempt:=full}"
 
 ### Transparent Hugepages
 # ATTENTION - one of two predefined values should be selected!
@@ -85,7 +85,7 @@ _preempt=${_preempt-full}
 # 'madvise' - madvise, prevent applications from allocating more memory resources than necessary
 # More infos here:
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/performance_tuning_guide/sect-red_hat_enterprise_linux-performance_tuning_guide-configuring_transparent_huge_pages
-_hugepage=${_hugepage-always}
+: "${_hugepage:=always}"
 
 # CPU compiler optimizations - Defaults to prompt at kernel config if left empty
 # AMD CPUs : "k8" "k8sse3" "k10" "barcelona" "bobcat" "jaguar" "bulldozer" "piledriver" "steamroller" "excavator" "zen" "zen2" "zen3" "zen4"
@@ -95,52 +95,52 @@ _hugepage=${_hugepage-always}
 # - "native_intel" (use compiler autodetection and will prompt for P6_NOPS - Selecting your arch manually in the list above is recommended instead of this option)
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 #
-_processor_opt=${_processor_opt-}
+: "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-_use_auto_optimization=${_use_auto_optimization-y}
+: "${_use_auto_optimization:=y}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
 # "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
 # "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
 # "none: disable LTO
-_use_llvm_lto=${_use_llvm_lto-none}
+: "${_use_llvm_lto:=none}"
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
 # y - enable -lto suffix
 # n - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-_use_lto_suffix=${_use_lto_suffix-y}
+: "${_use_lto_suffix:=y}"
 
 # Use suffix -gcc when requested by the user
 # This was added to facilitate https://github.com/CachyOS/linux-cachyos/issues/286
-_use_gcc_suffix=${_use_gcc_suffix-}
+: "${_use_gcc_suffix:=}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-_use_kcfi=${_use_kcfi-}
+: "${_use_kcfi:=}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-_build_zfs=${_build_zfs-}
+: "${_build_zfs:=}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-_build_nvidia=${_build_nvidia-}
+: "${_build_nvidia:=}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-_build_nvidia_open=${_build_nvidia_open-}
+: "${_build_nvidia_open:=}"
 
 # Build a debug package with non-stripped vmlinux
-_build_debug=${_build_debug-}
+: "${_build_debug:=}"
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {

--- a/linux-cachyos-bmq/PKGBUILD
+++ b/linux-cachyos-bmq/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-: "${_cachy_config:=y}"
+: "${_cachy_config:=yes}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -23,22 +23,22 @@
 : "${_cpusched:=bmq}"
 
 ### Tweak kernel options prior to a build via nconfig
-: "${_makenconfig:=}"
+: "${_makenconfig:=no}"
 
 ### Tweak kernel options prior to a build via menuconfig
-: "${_makemenuconfig:=}"
+: "${_makemenuconfig:=no}"
 
 ### Tweak kernel options prior to a build via xconfig
-: "${_makexconfig:=}"
+: "${_makexconfig:=no}"
 
 ### Tweak kernel options prior to a build via gconfig
-: "${_makegconfig:=}"
+: "${_makegconfig:=no}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-: "${_NUMAdisable:=}"
+: "${_NUMAdisable:=no}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,7 +48,7 @@
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-: "${_localmodcfg:=}"
+: "${_localmodcfg:=no}"
 
 # Path to the list of used modules
 : "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
@@ -58,16 +58,16 @@
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-: "${_use_current:=}"
+: "${_use_current:=no}"
 
 ### Enable KBUILD_CFLAGS -O3
-: "${_cc_harder:=y}"
+: "${_cc_harder:=yes}"
 
 ### Set performance governor as default
-: "${_per_gov:=}"
+: "${_per_gov:=no}"
 
 ### Enable TCP_CONG_BBR3
-: "${_tcp_bbr3:=}"
+: "${_tcp_bbr3:=no}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
 : "${_HZ_ticks:=1000}"
@@ -98,7 +98,7 @@
 : "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-: "${_use_auto_optimization:=y}"
+: "${_use_auto_optimization:=yes}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
@@ -109,38 +109,38 @@
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
-# y - enable -lto suffix
-# n - disable -lto suffix
+# yes - enable -lto suffix
+# no - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-: "${_use_lto_suffix:=y}"
+: "${_use_lto_suffix:=yes}"
 
 # Use suffix -gcc when requested by the user
 # This was added to facilitate https://github.com/CachyOS/linux-cachyos/issues/286
-: "${_use_gcc_suffix:=}"
+: "${_use_gcc_suffix:=no}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-: "${_use_kcfi:=}"
+: "${_use_kcfi:=no}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-: "${_build_zfs:=}"
+: "${_build_zfs:=no}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-: "${_build_nvidia:=}"
+: "${_build_nvidia:=no}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-: "${_build_nvidia_open:=}"
+: "${_build_nvidia_open:=no}"
 
 # Build a debug package with non-stripped vmlinux
-: "${_build_debug:=}"
+: "${_build_debug:=no}"
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
@@ -148,9 +148,9 @@ _is_lto_kernel() {
     return $?
 }
 
-if _is_lto_kernel && [ "$_use_lto_suffix" = "y"  ]; then
+if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix="cachyos-${_cpusched}-lto"
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "y" ]; then
+elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-${_cpusched}-gcc"
 else
     _pkgsuffix="cachyos-${_cpusched}"
@@ -216,18 +216,18 @@ if [[ "$_cpusched" = "rt" || "$_cpusched" = "rt-bore" ]]; then
 fi
 
 # ZFS support
-if [ -n "$_build_zfs" ]; then
+if [ "$_build_zfs" = "yes" ]; then
     makedepends+=(git)
     source+=("git+https://github.com/cachyos/zfs.git#commit=e65f69e41f4a276d7d0d1800a2878308a0ba84a6")
 fi
 
 # NVIDIA pre-build module support
-if [ -n "$_build_nvidia" ]; then
+if [ "$_build_nvidia" = "yes" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch")
 fi
 
-if [ -n "$_build_nvidia_open" ]; then
+if [ "$_build_nvidia_open" = "yes" ]; then
     source+=("nvidia-open-${_nv_ver}.tar.gz::https://github.com/NVIDIA/open-gpu-kernel-modules/archive/refs/tags/${_nv_ver}.tar.gz"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch"
              "${_patchsource}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch"
@@ -294,19 +294,17 @@ prepare() {
     fi
 
     ### Use autooptimization
-    if [ -n "$_use_auto_optimization" ]; then
+    if [ "$_use_auto_optimization" = "yes" ]; then
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
     ### Selecting CachyOS config
-    if [ -n "$_cachy_config" ]; then
+    if [ "$_cachy_config" = "yes" ]; then
         echo "Enabling CachyOS config..."
         scripts/config -e CACHY
     fi
 
     ### Selecting the CPU scheduler
-    [ -z "$_cpusched" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_cpusched" in
         cachyos|bore|hardened) scripts/config -e SCHED_BORE;;
         bmq) scripts/config -e SCHED_ALT -e SCHED_BMQ;;
@@ -319,14 +317,12 @@ prepare() {
     echo "Selecting ${_cpusched^^} CPU scheduler..."
 
     ### Enable KCFI
-    if [ -n "$_use_kcfi" ]; then
+    if [ "$_use_kcfi" = "yes" ]; then
         echo "Enabling kCFI"
         scripts/config -e ARCH_SUPPORTS_CFI_CLANG -e CFI_CLANG -e CFI_AUTO_DEFAULT
     fi
 
     ### Select LLVM level
-    [ -z "$_use_llvm_lto" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_use_llvm_lto" in
         thin) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -d LTO_CLANG_FULL -e LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
         full) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -e LTO_CLANG_FULL -d LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
@@ -337,8 +333,6 @@ prepare() {
     echo "Selecting '$_use_llvm_lto' LLVM level..."
 
     ### Select tick rate
-    [ -z "$_HZ_ticks" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_HZ_ticks" in
         100|250|500|600|625|750|1000)
             scripts/config -d HZ_300 -e "HZ_${_HZ_ticks}" --set-val HZ "${_HZ_ticks}";;
@@ -351,7 +345,7 @@ prepare() {
     echo "Setting tick rate to ${_HZ_ticks}Hz..."
 
     ### Disable NUMA
-    if [ -n "$_NUMAdisable" ]; then
+    if [ "$_NUMAdisable" = "yes" ]; then
         echo "Disabling NUMA from kernel config..."
         scripts/config -d NUMA \
             -d AMD_NUMA \
@@ -369,15 +363,13 @@ prepare() {
     fi
 
     ### Select performance governor
-    if [ -n "$_per_gov" ]; then
+    if [ "$_per_gov" = "yes" ]; then
         echo "Setting performance governor..."
         scripts/config -d CPU_FREQ_DEFAULT_GOV_SCHEDUTIL \
             -e CPU_FREQ_DEFAULT_GOV_PERFORMANCE
     fi
 
     ### Select tick type
-    [ -z "$_tickrate" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_tickrate" in
         perodic) scripts/config -d NO_HZ_IDLE -d NO_HZ_FULL -d NO_HZ -d NO_HZ_COMMON -e HZ_PERIODIC;;
         idle) scripts/config -d HZ_PERIODIC -d NO_HZ_FULL -e NO_HZ_IDLE  -e NO_HZ -e NO_HZ_COMMON;;
@@ -391,8 +383,6 @@ prepare() {
 
     # We should not set up the PREEMPT for RT kernels
     if [[ "$_cpusched" != "rt" || "$_cpusched" != "rt-bore" ]]; then
-        [ -z "$_preempt" ] && _die "The value is empty. Choose the correct one again."
-
         case "$_preempt" in
             full) scripts/config -e PREEMPT_BUILD -d PREEMPT_NONE -d PREEMPT_VOLUNTARY -e PREEMPT -e PREEMPT_COUNT -e PREEMPTION -e PREEMPT_DYNAMIC;;
             voluntary) scripts/config -e PREEMPT_BUILD -d PREEMPT_NONE -e PREEMPT_VOLUNTARY -d PREEMPT -e PREEMPT_COUNT -e PREEMPTION -d PREEMPT_DYNAMIC;;
@@ -404,7 +394,7 @@ prepare() {
     fi
 
     ### Enable O3
-    if [ -n "$_cc_harder" ] && [ -z "$_cc_size" ]; then
+    if [ "$_cc_harder" = "yes" ]; then
         echo "Enabling KBUILD_CFLAGS -O3..."
         scripts/config -d CC_OPTIMIZE_FOR_PERFORMANCE \
             -e CC_OPTIMIZE_FOR_PERFORMANCE_O3
@@ -427,7 +417,7 @@ prepare() {
     fi
 
     ### Enable bbr3
-    if [ -n "$_tcp_bbr3" ]; then
+    if [ "$_tcp_bbr3" = "yes" ]; then
         echo "Disabling TCP_CONG_CUBIC..."
         scripts/config -m TCP_CONG_CUBIC \
             -d DEFAULT_CUBIC \
@@ -441,8 +431,6 @@ prepare() {
     fi
 
     ### Select THP
-    [ -z "$_hugepage" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_hugepage" in
         always) scripts/config -d TRANSPARENT_HUGEPAGE_MADVISE -e TRANSPARENT_HUGEPAGE_ALWAYS;;
         madvise) scripts/config -d TRANSPARENT_HUGEPAGE_ALWAYS -e TRANSPARENT_HUGEPAGE_MADVISE;;
@@ -456,7 +444,7 @@ prepare() {
 
     ### Optionally use running kernel's config
     # code originally by nous; http://aur.archlinux.org/packages.php?ID=40191
-    if [ -n "$_use_current" ]; then
+    if [ "$_use_current" = "yes" ]; then
         if [[ -s /proc/config.gz ]]; then
             echo "Extracting config from /proc/config.gz..."
             # modprobe configs
@@ -469,10 +457,9 @@ prepare() {
         fi
     fi
 
-
     ### Optionally load needed modules for the make localmodconfig
     # See https://aur.archlinux.org/packages/modprobed-db
-    if [ -n "$_localmodcfg" ]; then
+    if [ "$_localmodcfg" = "yes" ]; then
         if [ -e "$_localmodcfg_path" ]; then
             echo "Running Steven Rostedt's make localmodconfig now"
             make "${BUILD_FLAGS[@]}" LSMOD="${_localmodcfg_path}" localmodconfig
@@ -492,23 +479,23 @@ prepare() {
     echo "Prepared $pkgbase version $(<version)"
 
     ### Running make nconfig
-    [[ -z "$_makenconfig" ]] ||  make "${BUILD_FLAGS[@]}" nconfig
+    [ "$_makenconfig" = "yes" ] && make "${BUILD_FLAGS[@]}" nconfig
 
     ### Running make menuconfig
-    [[ -z "$_makemenuconfig" ]] ||  make "${BUILD_FLAGS[@]}" menuconfig
+    [ "$_makemenuconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" menuconfig
 
     ### Running make xconfig
-    [[ -z "$_makexconfig" ]] ||  make "${BUILD_FLAGS[@]}" xconfig
+    [ "$_makexconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" xconfig
 
     ### Running make gconfig
-    [[ -z "$_makegconfig" ]] ||  make "${BUILD_FLAGS[@]}" gconfig
+    [ "$_makegconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" gconfig
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
     local basedir="$(dirname "$(readlink "${srcdir}/config")")"
     cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
 
@@ -516,7 +503,7 @@ prepare() {
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_pkg}/kernel"
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_open_pkg}/kernel-open"
         # Fix for Zen5 error print in dmesg
         patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch" -d "${srcdir}/${_nv_open_pkg}"
@@ -540,20 +527,20 @@ build() {
        SYSSRC="${srcdir}/${_srcname}"
        SYSOUT="${srcdir}/${_srcname}"
     )
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         MODULE_FLAGS+=(NV_EXCLUDE_BUILD_MODULES='__EXCLUDE_MODULES')
         cd "${srcdir}/${_nv_pkg}/kernel"
         make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
 
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         cd "${srcdir}/${_nv_open_pkg}"
         MODULE_FLAGS+=(IGNORE_CC_MISMATCH=yes)
         CFLAGS= CXXFLAGS= LDFLAGS= make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
     fi
 
-    if [ -n "$_build_zfs" ]; then
+    if [ "$_build_zfs" = "yes" ]; then
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
@@ -745,11 +732,11 @@ _package-nvidia-open(){
 }
 
 pkgname=("$pkgbase")
-[ -n "$_build_debug" ] && pkgname+=("$pkgbase-dbg")
+[ "$_build_debug" = "yes" ] && pkgname+=("$pkgbase-dbg")
 pkgname+=("$pkgbase-headers")
-[ -n "$_build_zfs" ] && pkgname+=("$pkgbase-zfs")
-[ -n "$_build_nvidia" ] && pkgname+=("$pkgbase-nvidia")
-[ -n "$_build_nvidia_open" ] && pkgname+=("$pkgbase-nvidia-open")
+[ "$_build_zfs" = "yes" ] && pkgname+=("$pkgbase-zfs")
+[ "$_build_nvidia" = "yes" ] && pkgname+=("$pkgbase-nvidia")
+[ "$_build_nvidia_open" = "yes" ] && pkgname+=("$pkgbase-nvidia-open")
 for _p in "${pkgname[@]}"; do
     eval "package_$_p() {
     $(declare -f "_package${_p#$pkgbase}")

--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-: "${_cachy_config:=y}"
+: "${_cachy_config:=yes}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -23,22 +23,22 @@
 : "${_cpusched:=bore}"
 
 ### Tweak kernel options prior to a build via nconfig
-: "${_makenconfig:=}"
+: "${_makenconfig:=no}"
 
 ### Tweak kernel options prior to a build via menuconfig
-: "${_makemenuconfig:=}"
+: "${_makemenuconfig:=no}"
 
 ### Tweak kernel options prior to a build via xconfig
-: "${_makexconfig:=}"
+: "${_makexconfig:=no}"
 
 ### Tweak kernel options prior to a build via gconfig
-: "${_makegconfig:=}"
+: "${_makegconfig:=no}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-: "${_NUMAdisable:=}"
+: "${_NUMAdisable:=no}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,7 +48,7 @@
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-: "${_localmodcfg:=}"
+: "${_localmodcfg:=no}"
 
 # Path to the list of used modules
 : "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
@@ -58,16 +58,16 @@
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-: "${_use_current:=}"
+: "${_use_current:=no}"
 
 ### Enable KBUILD_CFLAGS -O3
-: "${_cc_harder:=y}"
+: "${_cc_harder:=yes}"
 
 ### Set performance governor as default
-: "${_per_gov:=}"
+: "${_per_gov:=no}"
 
 ### Enable TCP_CONG_BBR3
-: "${_tcp_bbr3:=}"
+: "${_tcp_bbr3:=no}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
 : "${_HZ_ticks:=1000}"
@@ -98,7 +98,7 @@
 : "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-: "${_use_auto_optimization:=y}"
+: "${_use_auto_optimization:=yes}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
@@ -109,10 +109,10 @@
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
-# y - enable -lto suffix
-# n - disable -lto suffix
+# yes - enable -lto suffix
+# no - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-: "${_use_lto_suffix:=y}"
+: "${_use_lto_suffix:=yes}"
 
 # Use suffix -gcc when requested by the user
 # This was added to facilitate https://github.com/CachyOS/linux-cachyos/issues/286
@@ -123,24 +123,24 @@
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-: "${_use_kcfi:=}"
+: "${_use_kcfi:=no}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-: "${_build_zfs:=}"
+: "${_build_zfs:=no}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-: "${_build_nvidia:=}"
+: "${_build_nvidia:=no}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-: "${_build_nvidia_open:=}"
+: "${_build_nvidia_open:=no}"
 
 # Build a debug package with non-stripped vmlinux
-: "${_build_debug:=}"
+: "${_build_debug:=no}"
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
@@ -148,9 +148,9 @@ _is_lto_kernel() {
     return $?
 }
 
-if _is_lto_kernel && [ "$_use_lto_suffix" = "y"  ]; then
+if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix="cachyos-${_cpusched}-lto"
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "y" ]; then
+elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-${_cpusched}-gcc"
 else
     _pkgsuffix="cachyos-${_cpusched}"
@@ -216,18 +216,18 @@ if [[ "$_cpusched" = "rt" || "$_cpusched" = "rt-bore" ]]; then
 fi
 
 # ZFS support
-if [ -n "$_build_zfs" ]; then
+if [ "$_build_zfs" = "yes" ]; then
     makedepends+=(git)
     source+=("git+https://github.com/cachyos/zfs.git#commit=e65f69e41f4a276d7d0d1800a2878308a0ba84a6")
 fi
 
 # NVIDIA pre-build module support
-if [ -n "$_build_nvidia" ]; then
+if [ "$_build_nvidia" = "yes" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch")
 fi
 
-if [ -n "$_build_nvidia_open" ]; then
+if [ "$_build_nvidia_open" = "yes" ]; then
     source+=("nvidia-open-${_nv_ver}.tar.gz::https://github.com/NVIDIA/open-gpu-kernel-modules/archive/refs/tags/${_nv_ver}.tar.gz"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch"
              "${_patchsource}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch"
@@ -294,19 +294,17 @@ prepare() {
     fi
 
     ### Use autooptimization
-    if [ -n "$_use_auto_optimization" ]; then
+    if [ "$_use_auto_optimization" = "yes" ]; then
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
     ### Selecting CachyOS config
-    if [ -n "$_cachy_config" ]; then
+    if [ "$_cachy_config" = "yes" ]; then
         echo "Enabling CachyOS config..."
         scripts/config -e CACHY
     fi
 
     ### Selecting the CPU scheduler
-    [ -z "$_cpusched" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_cpusched" in
         cachyos|bore|hardened) scripts/config -e SCHED_BORE;;
         bmq) scripts/config -e SCHED_ALT -e SCHED_BMQ;;
@@ -319,14 +317,12 @@ prepare() {
     echo "Selecting ${_cpusched^^} CPU scheduler..."
 
     ### Enable KCFI
-    if [ -n "$_use_kcfi" ]; then
+    if [ "$_use_kcfi" = "yes" ]; then
         echo "Enabling kCFI"
         scripts/config -e ARCH_SUPPORTS_CFI_CLANG -e CFI_CLANG -e CFI_AUTO_DEFAULT
     fi
 
     ### Select LLVM level
-    [ -z "$_use_llvm_lto" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_use_llvm_lto" in
         thin) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -d LTO_CLANG_FULL -e LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
         full) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -e LTO_CLANG_FULL -d LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
@@ -337,8 +333,6 @@ prepare() {
     echo "Selecting '$_use_llvm_lto' LLVM level..."
 
     ### Select tick rate
-    [ -z "$_HZ_ticks" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_HZ_ticks" in
         100|250|500|600|625|750|1000)
             scripts/config -d HZ_300 -e "HZ_${_HZ_ticks}" --set-val HZ "${_HZ_ticks}";;
@@ -351,7 +345,7 @@ prepare() {
     echo "Setting tick rate to ${_HZ_ticks}Hz..."
 
     ### Disable NUMA
-    if [ -n "$_NUMAdisable" ]; then
+    if [ "$_NUMAdisable" = "yes" ]; then
         echo "Disabling NUMA from kernel config..."
         scripts/config -d NUMA \
             -d AMD_NUMA \
@@ -369,15 +363,13 @@ prepare() {
     fi
 
     ### Select performance governor
-    if [ -n "$_per_gov" ]; then
+    if [ "$_per_gov" = "yes" ]; then
         echo "Setting performance governor..."
         scripts/config -d CPU_FREQ_DEFAULT_GOV_SCHEDUTIL \
             -e CPU_FREQ_DEFAULT_GOV_PERFORMANCE
     fi
 
     ### Select tick type
-    [ -z "$_tickrate" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_tickrate" in
         perodic) scripts/config -d NO_HZ_IDLE -d NO_HZ_FULL -d NO_HZ -d NO_HZ_COMMON -e HZ_PERIODIC;;
         idle) scripts/config -d HZ_PERIODIC -d NO_HZ_FULL -e NO_HZ_IDLE  -e NO_HZ -e NO_HZ_COMMON;;
@@ -391,8 +383,6 @@ prepare() {
 
     # We should not set up the PREEMPT for RT kernels
     if [[ "$_cpusched" != "rt" || "$_cpusched" != "rt-bore" ]]; then
-        [ -z "$_preempt" ] && _die "The value is empty. Choose the correct one again."
-
         case "$_preempt" in
             full) scripts/config -e PREEMPT_BUILD -d PREEMPT_NONE -d PREEMPT_VOLUNTARY -e PREEMPT -e PREEMPT_COUNT -e PREEMPTION -e PREEMPT_DYNAMIC;;
             voluntary) scripts/config -e PREEMPT_BUILD -d PREEMPT_NONE -e PREEMPT_VOLUNTARY -d PREEMPT -e PREEMPT_COUNT -e PREEMPTION -d PREEMPT_DYNAMIC;;
@@ -404,7 +394,7 @@ prepare() {
     fi
 
     ### Enable O3
-    if [ -n "$_cc_harder" ] && [ -z "$_cc_size" ]; then
+    if [ "$_cc_harder" = "yes" ]; then
         echo "Enabling KBUILD_CFLAGS -O3..."
         scripts/config -d CC_OPTIMIZE_FOR_PERFORMANCE \
             -e CC_OPTIMIZE_FOR_PERFORMANCE_O3
@@ -427,7 +417,7 @@ prepare() {
     fi
 
     ### Enable bbr3
-    if [ -n "$_tcp_bbr3" ]; then
+    if [ "$_tcp_bbr3" = "yes" ]; then
         echo "Disabling TCP_CONG_CUBIC..."
         scripts/config -m TCP_CONG_CUBIC \
             -d DEFAULT_CUBIC \
@@ -441,8 +431,6 @@ prepare() {
     fi
 
     ### Select THP
-    [ -z "$_hugepage" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_hugepage" in
         always) scripts/config -d TRANSPARENT_HUGEPAGE_MADVISE -e TRANSPARENT_HUGEPAGE_ALWAYS;;
         madvise) scripts/config -d TRANSPARENT_HUGEPAGE_ALWAYS -e TRANSPARENT_HUGEPAGE_MADVISE;;
@@ -456,7 +444,7 @@ prepare() {
 
     ### Optionally use running kernel's config
     # code originally by nous; http://aur.archlinux.org/packages.php?ID=40191
-    if [ -n "$_use_current" ]; then
+    if [ "$_use_current" = "yes" ]; then
         if [[ -s /proc/config.gz ]]; then
             echo "Extracting config from /proc/config.gz..."
             # modprobe configs
@@ -469,10 +457,9 @@ prepare() {
         fi
     fi
 
-
     ### Optionally load needed modules for the make localmodconfig
     # See https://aur.archlinux.org/packages/modprobed-db
-    if [ -n "$_localmodcfg" ]; then
+    if [ "$_localmodcfg" = "yes" ]; then
         if [ -e "$_localmodcfg_path" ]; then
             echo "Running Steven Rostedt's make localmodconfig now"
             make "${BUILD_FLAGS[@]}" LSMOD="${_localmodcfg_path}" localmodconfig
@@ -492,23 +479,23 @@ prepare() {
     echo "Prepared $pkgbase version $(<version)"
 
     ### Running make nconfig
-    [[ -z "$_makenconfig" ]] ||  make "${BUILD_FLAGS[@]}" nconfig
+    [ "$_makenconfig" = "yes" ] && make "${BUILD_FLAGS[@]}" nconfig
 
     ### Running make menuconfig
-    [[ -z "$_makemenuconfig" ]] ||  make "${BUILD_FLAGS[@]}" menuconfig
+    [ "$_makemenuconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" menuconfig
 
     ### Running make xconfig
-    [[ -z "$_makexconfig" ]] ||  make "${BUILD_FLAGS[@]}" xconfig
+    [ "$_makexconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" xconfig
 
     ### Running make gconfig
-    [[ -z "$_makegconfig" ]] ||  make "${BUILD_FLAGS[@]}" gconfig
+    [ "$_makegconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" gconfig
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
     local basedir="$(dirname "$(readlink "${srcdir}/config")")"
     cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
 
@@ -516,7 +503,7 @@ prepare() {
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_pkg}/kernel"
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_open_pkg}/kernel-open"
         # Fix for Zen5 error print in dmesg
         patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch" -d "${srcdir}/${_nv_open_pkg}"
@@ -540,20 +527,20 @@ build() {
        SYSSRC="${srcdir}/${_srcname}"
        SYSOUT="${srcdir}/${_srcname}"
     )
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         MODULE_FLAGS+=(NV_EXCLUDE_BUILD_MODULES='__EXCLUDE_MODULES')
         cd "${srcdir}/${_nv_pkg}/kernel"
         make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
 
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         cd "${srcdir}/${_nv_open_pkg}"
         MODULE_FLAGS+=(IGNORE_CC_MISMATCH=yes)
         CFLAGS= CXXFLAGS= LDFLAGS= make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
     fi
 
-    if [ -n "$_build_zfs" ]; then
+    if [ "$_build_zfs" = "yes" ]; then
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
@@ -745,11 +732,11 @@ _package-nvidia-open(){
 }
 
 pkgname=("$pkgbase")
-[ -n "$_build_debug" ] && pkgname+=("$pkgbase-dbg")
+[ "$_build_debug" = "yes" ] && pkgname+=("$pkgbase-dbg")
 pkgname+=("$pkgbase-headers")
-[ -n "$_build_zfs" ] && pkgname+=("$pkgbase-zfs")
-[ -n "$_build_nvidia" ] && pkgname+=("$pkgbase-nvidia")
-[ -n "$_build_nvidia_open" ] && pkgname+=("$pkgbase-nvidia-open")
+[ "$_build_zfs" = "yes" ] && pkgname+=("$pkgbase-zfs")
+[ "$_build_nvidia" = "yes" ] && pkgname+=("$pkgbase-nvidia")
+[ "$_build_nvidia_open" = "yes" ] && pkgname+=("$pkgbase-nvidia-open")
 for _p in "${pkgname[@]}"; do
     eval "package_$_p() {
     $(declare -f "_package${_p#$pkgbase}")

--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-_cachy_config=${_cachy_config-y}
+: "${_cachy_config:=y}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -20,25 +20,25 @@ _cachy_config=${_cachy_config-y}
 # 'eevdf' - select 'EEVDF Scheduler'
 # 'rt' - select EEVDF, but includes a series of realtime patches
 # 'rt-bore' - select Burst-Oriented Response Enhancer, but includes a series of realtime patches
-_cpusched=${_cpusched-bore}
+: "${_cpusched:=bore}"
 
 ### Tweak kernel options prior to a build via nconfig
-_makenconfig=${_makenconfig-}
+: "${_makenconfig:=}"
 
 ### Tweak kernel options prior to a build via menuconfig
-_makemenuconfig=${_makemenuconfig-}
+: "${_makemenuconfig:=}"
 
 ### Tweak kernel options prior to a build via xconfig
-_makexconfig=${_makexconfig-}
+: "${_makexconfig:=}"
 
 ### Tweak kernel options prior to a build via gconfig
-_makegconfig=${_makegconfig-}
+: "${_makegconfig:=}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-_NUMAdisable=${_NUMAdisable-}
+: "${_NUMAdisable:=}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,36 +48,36 @@ _NUMAdisable=${_NUMAdisable-}
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-_localmodcfg=${_localmodcfg-}
+: "${_localmodcfg:=}"
 
 # Path to the list of used modules
-_localmodcfg_path=${_localmodcfg_path-"$HOME/.config/modprobed.db"}
+: "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
 
 # Use the current kernel's .config file
 # Enabling this option will use the .config of the RUNNING kernel rather than
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-_use_current=${_use_current-}
+: "${_use_current:=}"
 
 ### Enable KBUILD_CFLAGS -O3
-_cc_harder=${_cc_harder-y}
+: "${_cc_harder:=y}"
 
 ### Set performance governor as default
-_per_gov=${_per_gov-}
+: "${_per_gov:=}"
 
 ### Enable TCP_CONG_BBR3
-_tcp_bbr3=${_tcp_bbr3-}
+: "${_tcp_bbr3:=}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
-_HZ_ticks=${_HZ_ticks-1000}
+: "${_HZ_ticks:=1000}"
 
 ## Choose between perodic, idle or full
 ### Full tickless can give higher performances in various cases but, depending on hardware, lower consistency.
-_tickrate=${_tickrate-full}
+: "${_tickrate:=full}"
 
 ## Choose between full(low-latency), voluntary or server
-_preempt=${_preempt-full}
+: "${_preempt:=full}"
 
 ### Transparent Hugepages
 # ATTENTION - one of two predefined values should be selected!
@@ -85,7 +85,7 @@ _preempt=${_preempt-full}
 # 'madvise' - madvise, prevent applications from allocating more memory resources than necessary
 # More infos here:
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/performance_tuning_guide/sect-red_hat_enterprise_linux-performance_tuning_guide-configuring_transparent_huge_pages
-_hugepage=${_hugepage-always}
+: "${_hugepage:=always}"
 
 # CPU compiler optimizations - Defaults to prompt at kernel config if left empty
 # AMD CPUs : "k8" "k8sse3" "k10" "barcelona" "bobcat" "jaguar" "bulldozer" "piledriver" "steamroller" "excavator" "zen" "zen2" "zen3" "zen4"
@@ -95,52 +95,52 @@ _hugepage=${_hugepage-always}
 # - "native_intel" (use compiler autodetection and will prompt for P6_NOPS - Selecting your arch manually in the list above is recommended instead of this option)
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 #
-_processor_opt=${_processor_opt-}
+: "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-_use_auto_optimization=${_use_auto_optimization-y}
+: "${_use_auto_optimization:=y}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
 # "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
 # "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
 # "none: disable LTO
-_use_llvm_lto=${_use_llvm_lto-none}
+: "${_use_llvm_lto:=none}"
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
 # y - enable -lto suffix
 # n - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-_use_lto_suffix=${_use_lto_suffix-y}
+: "${_use_lto_suffix:=y}"
 
 # Use suffix -gcc when requested by the user
 # This was added to facilitate https://github.com/CachyOS/linux-cachyos/issues/286
-_use_gcc_suffix=${_use_gcc_suffix-}
+: "${_use_gcc_suffix:=}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-_use_kcfi=${_use_kcfi-}
+: "${_use_kcfi:=}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-_build_zfs=${_build_zfs-}
+: "${_build_zfs:=}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-_build_nvidia=${_build_nvidia-}
+: "${_build_nvidia:=}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-_build_nvidia_open=${_build_nvidia_open-}
+: "${_build_nvidia_open:=}"
 
 # Build a debug package with non-stripped vmlinux
-_build_debug=${_build_debug-}
+: "${_build_debug:=}"
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {

--- a/linux-cachyos-deckify/PKGBUILD
+++ b/linux-cachyos-deckify/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-_cachy_config=${_cachy_config-y}
+: "${_cachy_config:=y}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -20,25 +20,25 @@ _cachy_config=${_cachy_config-y}
 # 'eevdf' - select 'EEVDF Scheduler'
 # 'rt' - select EEVDF, but includes a series of realtime patches
 # 'rt-bore' - select Burst-Oriented Response Enhancer, but includes a series of realtime patches
-_cpusched=${_cpusched-cachyos}
+: "${_cpusched:=cachyos}"
 
 ### Tweak kernel options prior to a build via nconfig
-_makenconfig=${_makenconfig-}
+: "${_makenconfig:=}"
 
 ### Tweak kernel options prior to a build via menuconfig
-_makemenuconfig=${_makemenuconfig-}
+: "${_makemenuconfig:=}"
 
 ### Tweak kernel options prior to a build via xconfig
-_makexconfig=${_makexconfig-}
+: "${_makexconfig:=}"
 
 ### Tweak kernel options prior to a build via gconfig
-_makegconfig=${_makegconfig-}
+: "${_makegconfig:=}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-_NUMAdisable=${_NUMAdisable-}
+: "${_NUMAdisable:=}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,36 +48,36 @@ _NUMAdisable=${_NUMAdisable-}
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-_localmodcfg=${_localmodcfg-}
+: "${_localmodcfg:=}"
 
 # Path to the list of used modules
-_localmodcfg_path=${_localmodcfg_path-"$HOME/.config/modprobed.db"}
+: "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
 
 # Use the current kernel's .config file
 # Enabling this option will use the .config of the RUNNING kernel rather than
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-_use_current=${_use_current-}
+: "${_use_current:=}"
 
 ### Enable KBUILD_CFLAGS -O3
-_cc_harder=${_cc_harder-y}
+: "${_cc_harder:=y}"
 
 ### Set performance governor as default
-_per_gov=${_per_gov-}
+: "${_per_gov:=}"
 
 ### Enable TCP_CONG_BBR3
-_tcp_bbr3=${_tcp_bbr3-}
+: "${_tcp_bbr3:=}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
-_HZ_ticks=${_HZ_ticks-1000}
+: "${_HZ_ticks:=1000}"
 
 ## Choose between perodic, idle or full
 ### Full tickless can give higher performances in various cases but, depending on hardware, lower consistency.
-_tickrate=${_tickrate-full}
+: "${_tickrate:=full}"
 
 ## Choose between full(low-latency), voluntary or server
-_preempt=${_preempt-full}
+: "${_preempt:=full}"
 
 ### Transparent Hugepages
 # ATTENTION - one of two predefined values should be selected!
@@ -85,7 +85,7 @@ _preempt=${_preempt-full}
 # 'madvise' - madvise, prevent applications from allocating more memory resources than necessary
 # More infos here:
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/performance_tuning_guide/sect-red_hat_enterprise_linux-performance_tuning_guide-configuring_transparent_huge_pages
-_hugepage=${_hugepage-always}
+: "${_hugepage:=always}"
 
 # CPU compiler optimizations - Defaults to prompt at kernel config if left empty
 # AMD CPUs : "k8" "k8sse3" "k10" "barcelona" "bobcat" "jaguar" "bulldozer" "piledriver" "steamroller" "excavator" "zen" "zen2" "zen3" "zen4"
@@ -95,51 +95,51 @@ _hugepage=${_hugepage-always}
 # - "native_intel" (use compiler autodetection and will prompt for P6_NOPS - Selecting your arch manually in the list above is recommended instead of this option)
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 #
-_processor_opt=${_processor_opt-}
+: "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-_use_auto_optimization=${_use_auto_optimization-y}
+: "${_use_auto_optimization:=y}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
 # "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
 # "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
 # "none: disable LTO
-_use_llvm_lto=${_use_llvm_lto-none}
+: "${_use_llvm_lto:=none}"
 
 # Use suffix -lto only when requested by the user
 # y - enable -lto suffix
 # n - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-_use_lto_suffix=${_use_lto_suffix-y}
+: "${_use_lto_suffix:=y}"
 
 # Use suffix -gcc when requested by the user
 # This was added to facilitate https://github.com/CachyOS/linux-cachyos/issues/286
-_use_gcc_suffix=${_use_gcc_suffix-}
+: "${_use_gcc_suffix:=}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-_use_kcfi=${_use_kcfi-}
+: "${_use_kcfi:=}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-_build_zfs=${_build_zfs-}
+: "${_build_zfs:=}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-_build_nvidia=${_build_nvidia-}
+: "${_build_nvidia:=}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-_build_nvidia_open=${_build_nvidia_open-}
+: "${_build_nvidia_open:=}"
 
 # Build a debug package with non-stripped vmlinux
-_build_debug=${_build_debug-}
+: "${_build_debug:=}"
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {

--- a/linux-cachyos-deckify/PKGBUILD
+++ b/linux-cachyos-deckify/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-: "${_cachy_config:=y}"
+: "${_cachy_config:=yes}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -23,22 +23,22 @@
 : "${_cpusched:=cachyos}"
 
 ### Tweak kernel options prior to a build via nconfig
-: "${_makenconfig:=}"
+: "${_makenconfig:=no}"
 
 ### Tweak kernel options prior to a build via menuconfig
-: "${_makemenuconfig:=}"
+: "${_makemenuconfig:=no}"
 
 ### Tweak kernel options prior to a build via xconfig
-: "${_makexconfig:=}"
+: "${_makexconfig:=no}"
 
 ### Tweak kernel options prior to a build via gconfig
-: "${_makegconfig:=}"
+: "${_makegconfig:=no}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-: "${_NUMAdisable:=}"
+: "${_NUMAdisable:=no}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,7 +48,7 @@
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-: "${_localmodcfg:=}"
+: "${_localmodcfg:=no}"
 
 # Path to the list of used modules
 : "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
@@ -58,16 +58,16 @@
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-: "${_use_current:=}"
+: "${_use_current:=no}"
 
 ### Enable KBUILD_CFLAGS -O3
-: "${_cc_harder:=y}"
+: "${_cc_harder:=yes}"
 
 ### Set performance governor as default
-: "${_per_gov:=}"
+: "${_per_gov:=no}"
 
 ### Enable TCP_CONG_BBR3
-: "${_tcp_bbr3:=}"
+: "${_tcp_bbr3:=no}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
 : "${_HZ_ticks:=1000}"
@@ -98,7 +98,7 @@
 : "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-: "${_use_auto_optimization:=y}"
+: "${_use_auto_optimization:=yes}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
@@ -108,38 +108,38 @@
 : "${_use_llvm_lto:=none}"
 
 # Use suffix -lto only when requested by the user
-# y - enable -lto suffix
-# n - disable -lto suffix
+# yes - enable -lto suffix
+# no - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-: "${_use_lto_suffix:=y}"
+: "${_use_lto_suffix:=yes}"
 
 # Use suffix -gcc when requested by the user
 # This was added to facilitate https://github.com/CachyOS/linux-cachyos/issues/286
-: "${_use_gcc_suffix:=}"
+: "${_use_gcc_suffix:=no}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-: "${_use_kcfi:=}"
+: "${_use_kcfi:=no}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-: "${_build_zfs:=}"
+: "${_build_zfs:=no}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-: "${_build_nvidia:=}"
+: "${_build_nvidia:=no}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-: "${_build_nvidia_open:=}"
+: "${_build_nvidia_open:=no}"
 
 # Build a debug package with non-stripped vmlinux
-: "${_build_debug:=}"
+: "${_build_debug:=no}"
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
@@ -147,9 +147,9 @@ _is_lto_kernel() {
     return $?
 }
 
-if _is_lto_kernel && [ "$_use_lto_suffix" = "y"  ]; then
+if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix="cachyos-deckify-lto"
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "y" ]; then
+elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-deckify-gcc"
 else
     _pkgsuffix="cachyos-deckify"
@@ -217,18 +217,18 @@ if [[ "$_cpusched" = "rt" || "$_cpusched" = "rt-bore" ]]; then
 fi
 
 # ZFS support
-if [ -n "$_build_zfs" ]; then
+if [ "$_build_zfs" = "yes" ]; then
     makedepends+=(git)
     source+=("git+https://github.com/cachyos/zfs.git#commit=e65f69e41f4a276d7d0d1800a2878308a0ba84a6")
 fi
 
 # NVIDIA pre-build module support
-if [ -n "$_build_nvidia" ]; then
+if [ "$_build_nvidia" = "yes" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch")
 fi
 
-if [ -n "$_build_nvidia_open" ]; then
+if [ "$_build_nvidia_open" = "yes" ]; then
     source+=("nvidia-open-${_nv_ver}.tar.gz::https://github.com/NVIDIA/open-gpu-kernel-modules/archive/refs/tags/${_nv_ver}.tar.gz"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch"
              "${_patchsource}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch"
@@ -295,19 +295,17 @@ prepare() {
     fi
 
     ### Use autooptimization
-    if [ -n "$_use_auto_optimization" ]; then
+    if [ "$_use_auto_optimization" = "yes" ]; then
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
     ### Selecting CachyOS config
-    if [ -n "$_cachy_config" ]; then
+    if [ "$_cachy_config" = "yes" ]; then
         echo "Enabling CachyOS config..."
         scripts/config -e CACHY
     fi
 
     ### Selecting the CPU scheduler
-    [ -z "$_cpusched" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_cpusched" in
         cachyos|bore|hardened) scripts/config -e SCHED_BORE;;
         bmq) scripts/config -e SCHED_ALT -e SCHED_BMQ;;
@@ -320,14 +318,12 @@ prepare() {
     echo "Selecting ${_cpusched^^} CPU scheduler..."
 
     ### Enable KCFI
-    if [ -n "$_use_kcfi" ]; then
+    if [ "$_use_kcfi" = "yes" ]; then
         echo "Enabling kCFI"
         scripts/config -e ARCH_SUPPORTS_CFI_CLANG -e CFI_CLANG -e CFI_AUTO_DEFAULT
     fi
 
     ### Select LLVM level
-    [ -z "$_use_llvm_lto" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_use_llvm_lto" in
         thin) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -d LTO_CLANG_FULL -e LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
         full) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -e LTO_CLANG_FULL -d LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
@@ -338,8 +334,6 @@ prepare() {
     echo "Selecting '$_use_llvm_lto' LLVM level..."
 
     ### Select tick rate
-    [ -z "$_HZ_ticks" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_HZ_ticks" in
         100|250|500|600|625|750|1000)
             scripts/config -d HZ_300 -e "HZ_${_HZ_ticks}" --set-val HZ "${_HZ_ticks}";;
@@ -352,7 +346,7 @@ prepare() {
     echo "Setting tick rate to ${_HZ_ticks}Hz..."
 
     ### Disable NUMA
-    if [ -n "$_NUMAdisable" ]; then
+    if [ "$_NUMAdisable" = "yes" ]; then
         echo "Disabling NUMA from kernel config..."
         scripts/config -d NUMA \
             -d AMD_NUMA \
@@ -370,15 +364,13 @@ prepare() {
     fi
 
     ### Select performance governor
-    if [ -n "$_per_gov" ]; then
+    if [ "$_per_gov" = "yes" ]; then
         echo "Setting performance governor..."
         scripts/config -d CPU_FREQ_DEFAULT_GOV_SCHEDUTIL \
             -e CPU_FREQ_DEFAULT_GOV_PERFORMANCE
     fi
 
     ### Select tick type
-    [ -z "$_tickrate" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_tickrate" in
         perodic) scripts/config -d NO_HZ_IDLE -d NO_HZ_FULL -d NO_HZ -d NO_HZ_COMMON -e HZ_PERIODIC;;
         idle) scripts/config -d HZ_PERIODIC -d NO_HZ_FULL -e NO_HZ_IDLE  -e NO_HZ -e NO_HZ_COMMON;;
@@ -392,8 +384,6 @@ prepare() {
 
     # We should not set up the PREEMPT for RT kernels
     if [[ "$_cpusched" != "rt" || "$_cpusched" != "rt-bore" ]]; then
-        [ -z "$_preempt" ] && _die "The value is empty. Choose the correct one again."
-
         case "$_preempt" in
             full) scripts/config -e PREEMPT_BUILD -d PREEMPT_NONE -d PREEMPT_VOLUNTARY -e PREEMPT -e PREEMPT_COUNT -e PREEMPTION -e PREEMPT_DYNAMIC;;
             voluntary) scripts/config -e PREEMPT_BUILD -d PREEMPT_NONE -e PREEMPT_VOLUNTARY -d PREEMPT -e PREEMPT_COUNT -e PREEMPTION -d PREEMPT_DYNAMIC;;
@@ -405,7 +395,7 @@ prepare() {
     fi
 
     ### Enable O3
-    if [ -n "$_cc_harder" ] && [ -z "$_cc_size" ]; then
+    if [ "$_cc_harder" = "yes" ]; then
         echo "Enabling KBUILD_CFLAGS -O3..."
         scripts/config -d CC_OPTIMIZE_FOR_PERFORMANCE \
             -e CC_OPTIMIZE_FOR_PERFORMANCE_O3
@@ -428,7 +418,7 @@ prepare() {
     fi
 
     ### Enable bbr3
-    if [ -n "$_tcp_bbr3" ]; then
+    if [ "$_tcp_bbr3" = "yes" ]; then
         echo "Disabling TCP_CONG_CUBIC..."
         scripts/config -m TCP_CONG_CUBIC \
             -d DEFAULT_CUBIC \
@@ -442,8 +432,6 @@ prepare() {
     fi
 
     ### Select THP
-    [ -z "$_hugepage" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_hugepage" in
         always) scripts/config -d TRANSPARENT_HUGEPAGE_MADVISE -e TRANSPARENT_HUGEPAGE_ALWAYS;;
         madvise) scripts/config -d TRANSPARENT_HUGEPAGE_ALWAYS -e TRANSPARENT_HUGEPAGE_MADVISE;;
@@ -457,7 +445,7 @@ prepare() {
 
     ### Optionally use running kernel's config
     # code originally by nous; http://aur.archlinux.org/packages.php?ID=40191
-    if [ -n "$_use_current" ]; then
+    if [ "$_use_current" = "yes" ]; then
         if [[ -s /proc/config.gz ]]; then
             echo "Extracting config from /proc/config.gz..."
             # modprobe configs
@@ -470,10 +458,9 @@ prepare() {
         fi
     fi
 
-
     ### Optionally load needed modules for the make localmodconfig
     # See https://aur.archlinux.org/packages/modprobed-db
-    if [ -n "$_localmodcfg" ]; then
+    if [ "$_localmodcfg" = "yes" ]; then
         if [ -e "$_localmodcfg_path" ]; then
             echo "Running Steven Rostedt's make localmodconfig now"
             make "${BUILD_FLAGS[@]}" LSMOD="${_localmodcfg_path}" localmodconfig
@@ -493,23 +480,23 @@ prepare() {
     echo "Prepared $pkgbase version $(<version)"
 
     ### Running make nconfig
-    [[ -z "$_makenconfig" ]] ||  make "${BUILD_FLAGS[@]}" nconfig
+    [ "$_makenconfig" = "yes" ] && make "${BUILD_FLAGS[@]}" nconfig
 
     ### Running make menuconfig
-    [[ -z "$_makemenuconfig" ]] ||  make "${BUILD_FLAGS[@]}" menuconfig
+    [ "$_makemenuconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" menuconfig
 
     ### Running make xconfig
-    [[ -z "$_makexconfig" ]] ||  make "${BUILD_FLAGS[@]}" xconfig
+    [ "$_makexconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" xconfig
 
     ### Running make gconfig
-    [[ -z "$_makegconfig" ]] ||  make "${BUILD_FLAGS[@]}" gconfig
+    [ "$_makegconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" gconfig
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
     local basedir="$(dirname "$(readlink "${srcdir}/config")")"
     cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
 
@@ -517,7 +504,7 @@ prepare() {
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_pkg}/kernel"
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_open_pkg}/kernel-open"
         # Fix for Zen5 error print in dmesg
         patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch" -d "${srcdir}/${_nv_open_pkg}"
@@ -541,20 +528,20 @@ build() {
        SYSSRC="${srcdir}/${_srcname}"
        SYSOUT="${srcdir}/${_srcname}"
     )
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         MODULE_FLAGS+=(NV_EXCLUDE_BUILD_MODULES='__EXCLUDE_MODULES')
         cd "${srcdir}/${_nv_pkg}/kernel"
         make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
 
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         cd "${srcdir}/${_nv_open_pkg}"
         MODULE_FLAGS+=(IGNORE_CC_MISMATCH=yes)
         CFLAGS= CXXFLAGS= LDFLAGS= make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
     fi
 
-    if [ -n "$_build_zfs" ]; then
+    if [ "$_build_zfs" = "yes" ]; then
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
@@ -746,11 +733,11 @@ _package-nvidia-open(){
 }
 
 pkgname=("$pkgbase")
-[ -n "$_build_debug" ] && pkgname+=("$pkgbase-dbg")
+[ "$_build_debug" = "yes" ] && pkgname+=("$pkgbase-dbg")
 pkgname+=("$pkgbase-headers")
-[ -n "$_build_zfs" ] && pkgname+=("$pkgbase-zfs")
-[ -n "$_build_nvidia" ] && pkgname+=("$pkgbase-nvidia")
-[ -n "$_build_nvidia_open" ] && pkgname+=("$pkgbase-nvidia-open")
+[ "$_build_zfs" = "yes" ] && pkgname+=("$pkgbase-zfs")
+[ "$_build_nvidia" = "yes" ] && pkgname+=("$pkgbase-nvidia")
+[ "$_build_nvidia_open" = "yes" ] && pkgname+=("$pkgbase-nvidia-open")
 for _p in "${pkgname[@]}"; do
     eval "package_$_p() {
     $(declare -f "_package${_p#$pkgbase}")

--- a/linux-cachyos-eevdf/PKGBUILD
+++ b/linux-cachyos-eevdf/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-_cachy_config=${_cachy_config-y}
+: "${_cachy_config:=y}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -20,25 +20,25 @@ _cachy_config=${_cachy_config-y}
 # 'eevdf' - select 'EEVDF Scheduler'
 # 'rt' - select EEVDF, but includes a series of realtime patches
 # 'rt-bore' - select Burst-Oriented Response Enhancer, but includes a series of realtime patches
-_cpusched=${_cpusched-eevdf}
+: "${_cpusched:=eevdf}"
 
 ### Tweak kernel options prior to a build via nconfig
-_makenconfig=${_makenconfig-}
+: "${_makenconfig:=}"
 
 ### Tweak kernel options prior to a build via menuconfig
-_makemenuconfig=${_makemenuconfig-}
+: "${_makemenuconfig:=}"
 
 ### Tweak kernel options prior to a build via xconfig
-_makexconfig=${_makexconfig-}
+: "${_makexconfig:=}"
 
 ### Tweak kernel options prior to a build via gconfig
-_makegconfig=${_makegconfig-}
+: "${_makegconfig:=}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-_NUMAdisable=${_NUMAdisable-}
+: "${_NUMAdisable:=}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,36 +48,36 @@ _NUMAdisable=${_NUMAdisable-}
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-_localmodcfg=${_localmodcfg-}
+: "${_localmodcfg:=}"
 
 # Path to the list of used modules
-_localmodcfg_path=${_localmodcfg_path-"$HOME/.config/modprobed.db"}
+: "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
 
 # Use the current kernel's .config file
 # Enabling this option will use the .config of the RUNNING kernel rather than
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-_use_current=${_use_current-}
+: "${_use_current:=}"
 
 ### Enable KBUILD_CFLAGS -O3
-_cc_harder=${_cc_harder-y}
+: "${_cc_harder:=y}"
 
 ### Set performance governor as default
-_per_gov=${_per_gov-}
+: "${_per_gov:=}"
 
 ### Enable TCP_CONG_BBR3
-_tcp_bbr3=${_tcp_bbr3-}
+: "${_tcp_bbr3:=}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
-_HZ_ticks=${_HZ_ticks-1000}
+: "${_HZ_ticks:=1000}"
 
 ## Choose between perodic, idle or full
 ### Full tickless can give higher performances in various cases but, depending on hardware, lower consistency.
-_tickrate=${_tickrate-full}
+: "${_tickrate:=full}"
 
 ## Choose between full(low-latency), voluntary or server
-_preempt=${_preempt-full}
+: "${_preempt:=full}"
 
 ### Transparent Hugepages
 # ATTENTION - one of two predefined values should be selected!
@@ -85,7 +85,7 @@ _preempt=${_preempt-full}
 # 'madvise' - madvise, prevent applications from allocating more memory resources than necessary
 # More infos here:
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/performance_tuning_guide/sect-red_hat_enterprise_linux-performance_tuning_guide-configuring_transparent_huge_pages
-_hugepage=${_hugepage-always}
+: "${_hugepage:=always}"
 
 # CPU compiler optimizations - Defaults to prompt at kernel config if left empty
 # AMD CPUs : "k8" "k8sse3" "k10" "barcelona" "bobcat" "jaguar" "bulldozer" "piledriver" "steamroller" "excavator" "zen" "zen2" "zen3" "zen4"
@@ -95,52 +95,52 @@ _hugepage=${_hugepage-always}
 # - "native_intel" (use compiler autodetection and will prompt for P6_NOPS - Selecting your arch manually in the list above is recommended instead of this option)
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 #
-_processor_opt=${_processor_opt-}
+: "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-_use_auto_optimization=${_use_auto_optimization-y}
+: "${_use_auto_optimization:=y}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
 # "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
 # "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
 # "none: disable LTO
-_use_llvm_lto=${_use_llvm_lto-none}
+: "${_use_llvm_lto:=none}"
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
 # y - enable -lto suffix
 # n - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-_use_lto_suffix=${_use_lto_suffix-y}
+: "${_use_lto_suffix:=y}"
 
 # Use suffix -gcc when requested by the user
 # This was added to facilitate https://github.com/CachyOS/linux-cachyos/issues/286
-_use_gcc_suffix=${_use_gcc_suffix-}
+: "${_use_gcc_suffix:=}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-_use_kcfi=${_use_kcfi-}
+: "${_use_kcfi:=}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-_build_zfs=${_build_zfs-}
+: "${_build_zfs:=}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-_build_nvidia=${_build_nvidia-}
+: "${_build_nvidia:=}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-_build_nvidia_open=${_build_nvidia_open-}
+: "${_build_nvidia_open:=}"
 
 # Build a debug package with non-stripped vmlinux
-_build_debug=${_build_debug-}
+: "${_build_debug:=}"
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {

--- a/linux-cachyos-eevdf/PKGBUILD
+++ b/linux-cachyos-eevdf/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-: "${_cachy_config:=y}"
+: "${_cachy_config:=yes}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -23,22 +23,22 @@
 : "${_cpusched:=eevdf}"
 
 ### Tweak kernel options prior to a build via nconfig
-: "${_makenconfig:=}"
+: "${_makenconfig:=no}"
 
 ### Tweak kernel options prior to a build via menuconfig
-: "${_makemenuconfig:=}"
+: "${_makemenuconfig:=no}"
 
 ### Tweak kernel options prior to a build via xconfig
-: "${_makexconfig:=}"
+: "${_makexconfig:=no}"
 
 ### Tweak kernel options prior to a build via gconfig
-: "${_makegconfig:=}"
+: "${_makegconfig:=no}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-: "${_NUMAdisable:=}"
+: "${_NUMAdisable:=no}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,7 +48,7 @@
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-: "${_localmodcfg:=}"
+: "${_localmodcfg:=no}"
 
 # Path to the list of used modules
 : "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
@@ -58,16 +58,16 @@
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-: "${_use_current:=}"
+: "${_use_current:=no}"
 
 ### Enable KBUILD_CFLAGS -O3
-: "${_cc_harder:=y}"
+: "${_cc_harder:=yes}"
 
 ### Set performance governor as default
-: "${_per_gov:=}"
+: "${_per_gov:=no}"
 
 ### Enable TCP_CONG_BBR3
-: "${_tcp_bbr3:=}"
+: "${_tcp_bbr3:=no}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
 : "${_HZ_ticks:=1000}"
@@ -98,7 +98,7 @@
 : "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-: "${_use_auto_optimization:=y}"
+: "${_use_auto_optimization:=yes}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
@@ -109,38 +109,38 @@
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
-# y - enable -lto suffix
-# n - disable -lto suffix
+# yes - enable -lto suffix
+# no - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-: "${_use_lto_suffix:=y}"
+: "${_use_lto_suffix:=yes}"
 
 # Use suffix -gcc when requested by the user
 # This was added to facilitate https://github.com/CachyOS/linux-cachyos/issues/286
-: "${_use_gcc_suffix:=}"
+: "${_use_gcc_suffix:=no}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-: "${_use_kcfi:=}"
+: "${_use_kcfi:=no}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-: "${_build_zfs:=}"
+: "${_build_zfs:=no}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-: "${_build_nvidia:=}"
+: "${_build_nvidia:=no}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-: "${_build_nvidia_open:=}"
+: "${_build_nvidia_open:=no}"
 
 # Build a debug package with non-stripped vmlinux
-: "${_build_debug:=}"
+: "${_build_debug:=no}"
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
@@ -148,9 +148,9 @@ _is_lto_kernel() {
     return $?
 }
 
-if _is_lto_kernel && [ "$_use_lto_suffix" = "y"  ]; then
+if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix="cachyos-${_cpusched}-lto"
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "y" ]; then
+elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-${_cpusched}-gcc"
 else
     _pkgsuffix="cachyos-${_cpusched}"
@@ -216,18 +216,18 @@ if [[ "$_cpusched" = "rt" || "$_cpusched" = "rt-bore" ]]; then
 fi
 
 # ZFS support
-if [ -n "$_build_zfs" ]; then
+if [ "$_build_zfs" = "yes" ]; then
     makedepends+=(git)
     source+=("git+https://github.com/cachyos/zfs.git#commit=e65f69e41f4a276d7d0d1800a2878308a0ba84a6")
 fi
 
 # NVIDIA pre-build module support
-if [ -n "$_build_nvidia" ]; then
+if [ "$_build_nvidia" = "yes" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch")
 fi
 
-if [ -n "$_build_nvidia_open" ]; then
+if [ "$_build_nvidia_open" = "yes" ]; then
     source+=("nvidia-open-${_nv_ver}.tar.gz::https://github.com/NVIDIA/open-gpu-kernel-modules/archive/refs/tags/${_nv_ver}.tar.gz"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch"
              "${_patchsource}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch"
@@ -294,19 +294,17 @@ prepare() {
     fi
 
     ### Use autooptimization
-    if [ -n "$_use_auto_optimization" ]; then
+    if [ "$_use_auto_optimization" = "yes" ]; then
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
     ### Selecting CachyOS config
-    if [ -n "$_cachy_config" ]; then
+    if [ "$_cachy_config" = "yes" ]; then
         echo "Enabling CachyOS config..."
         scripts/config -e CACHY
     fi
 
     ### Selecting the CPU scheduler
-    [ -z "$_cpusched" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_cpusched" in
         cachyos|bore|hardened) scripts/config -e SCHED_BORE;;
         bmq) scripts/config -e SCHED_ALT -e SCHED_BMQ;;
@@ -319,14 +317,12 @@ prepare() {
     echo "Selecting ${_cpusched^^} CPU scheduler..."
 
     ### Enable KCFI
-    if [ -n "$_use_kcfi" ]; then
+    if [ "$_use_kcfi" = "yes" ]; then
         echo "Enabling kCFI"
         scripts/config -e ARCH_SUPPORTS_CFI_CLANG -e CFI_CLANG -e CFI_AUTO_DEFAULT
     fi
 
     ### Select LLVM level
-    [ -z "$_use_llvm_lto" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_use_llvm_lto" in
         thin) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -d LTO_CLANG_FULL -e LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
         full) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -e LTO_CLANG_FULL -d LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
@@ -337,8 +333,6 @@ prepare() {
     echo "Selecting '$_use_llvm_lto' LLVM level..."
 
     ### Select tick rate
-    [ -z "$_HZ_ticks" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_HZ_ticks" in
         100|250|500|600|625|750|1000)
             scripts/config -d HZ_300 -e "HZ_${_HZ_ticks}" --set-val HZ "${_HZ_ticks}";;
@@ -351,7 +345,7 @@ prepare() {
     echo "Setting tick rate to ${_HZ_ticks}Hz..."
 
     ### Disable NUMA
-    if [ -n "$_NUMAdisable" ]; then
+    if [ "$_NUMAdisable" = "yes" ]; then
         echo "Disabling NUMA from kernel config..."
         scripts/config -d NUMA \
             -d AMD_NUMA \
@@ -369,15 +363,13 @@ prepare() {
     fi
 
     ### Select performance governor
-    if [ -n "$_per_gov" ]; then
+    if [ "$_per_gov" = "yes" ]; then
         echo "Setting performance governor..."
         scripts/config -d CPU_FREQ_DEFAULT_GOV_SCHEDUTIL \
             -e CPU_FREQ_DEFAULT_GOV_PERFORMANCE
     fi
 
     ### Select tick type
-    [ -z "$_tickrate" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_tickrate" in
         perodic) scripts/config -d NO_HZ_IDLE -d NO_HZ_FULL -d NO_HZ -d NO_HZ_COMMON -e HZ_PERIODIC;;
         idle) scripts/config -d HZ_PERIODIC -d NO_HZ_FULL -e NO_HZ_IDLE  -e NO_HZ -e NO_HZ_COMMON;;
@@ -391,8 +383,6 @@ prepare() {
 
     # We should not set up the PREEMPT for RT kernels
     if [[ "$_cpusched" != "rt" || "$_cpusched" != "rt-bore" ]]; then
-        [ -z "$_preempt" ] && _die "The value is empty. Choose the correct one again."
-
         case "$_preempt" in
             full) scripts/config -e PREEMPT_BUILD -d PREEMPT_NONE -d PREEMPT_VOLUNTARY -e PREEMPT -e PREEMPT_COUNT -e PREEMPTION -e PREEMPT_DYNAMIC;;
             voluntary) scripts/config -e PREEMPT_BUILD -d PREEMPT_NONE -e PREEMPT_VOLUNTARY -d PREEMPT -e PREEMPT_COUNT -e PREEMPTION -d PREEMPT_DYNAMIC;;
@@ -404,7 +394,7 @@ prepare() {
     fi
 
     ### Enable O3
-    if [ -n "$_cc_harder" ] && [ -z "$_cc_size" ]; then
+    if [ "$_cc_harder" = "yes" ]; then
         echo "Enabling KBUILD_CFLAGS -O3..."
         scripts/config -d CC_OPTIMIZE_FOR_PERFORMANCE \
             -e CC_OPTIMIZE_FOR_PERFORMANCE_O3
@@ -427,7 +417,7 @@ prepare() {
     fi
 
     ### Enable bbr3
-    if [ -n "$_tcp_bbr3" ]; then
+    if [ "$_tcp_bbr3" = "yes" ]; then
         echo "Disabling TCP_CONG_CUBIC..."
         scripts/config -m TCP_CONG_CUBIC \
             -d DEFAULT_CUBIC \
@@ -441,8 +431,6 @@ prepare() {
     fi
 
     ### Select THP
-    [ -z "$_hugepage" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_hugepage" in
         always) scripts/config -d TRANSPARENT_HUGEPAGE_MADVISE -e TRANSPARENT_HUGEPAGE_ALWAYS;;
         madvise) scripts/config -d TRANSPARENT_HUGEPAGE_ALWAYS -e TRANSPARENT_HUGEPAGE_MADVISE;;
@@ -456,7 +444,7 @@ prepare() {
 
     ### Optionally use running kernel's config
     # code originally by nous; http://aur.archlinux.org/packages.php?ID=40191
-    if [ -n "$_use_current" ]; then
+    if [ "$_use_current" = "yes" ]; then
         if [[ -s /proc/config.gz ]]; then
             echo "Extracting config from /proc/config.gz..."
             # modprobe configs
@@ -469,10 +457,9 @@ prepare() {
         fi
     fi
 
-
     ### Optionally load needed modules for the make localmodconfig
     # See https://aur.archlinux.org/packages/modprobed-db
-    if [ -n "$_localmodcfg" ]; then
+    if [ "$_localmodcfg" = "yes" ]; then
         if [ -e "$_localmodcfg_path" ]; then
             echo "Running Steven Rostedt's make localmodconfig now"
             make "${BUILD_FLAGS[@]}" LSMOD="${_localmodcfg_path}" localmodconfig
@@ -492,23 +479,23 @@ prepare() {
     echo "Prepared $pkgbase version $(<version)"
 
     ### Running make nconfig
-    [[ -z "$_makenconfig" ]] ||  make "${BUILD_FLAGS[@]}" nconfig
+    [ "$_makenconfig" = "yes" ] && make "${BUILD_FLAGS[@]}" nconfig
 
     ### Running make menuconfig
-    [[ -z "$_makemenuconfig" ]] ||  make "${BUILD_FLAGS[@]}" menuconfig
+    [ "$_makemenuconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" menuconfig
 
     ### Running make xconfig
-    [[ -z "$_makexconfig" ]] ||  make "${BUILD_FLAGS[@]}" xconfig
+    [ "$_makexconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" xconfig
 
     ### Running make gconfig
-    [[ -z "$_makegconfig" ]] ||  make "${BUILD_FLAGS[@]}" gconfig
+    [ "$_makegconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" gconfig
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
     local basedir="$(dirname "$(readlink "${srcdir}/config")")"
     cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
 
@@ -516,7 +503,7 @@ prepare() {
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_pkg}/kernel"
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_open_pkg}/kernel-open"
         # Fix for Zen5 error print in dmesg
         patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch" -d "${srcdir}/${_nv_open_pkg}"
@@ -540,20 +527,20 @@ build() {
        SYSSRC="${srcdir}/${_srcname}"
        SYSOUT="${srcdir}/${_srcname}"
     )
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         MODULE_FLAGS+=(NV_EXCLUDE_BUILD_MODULES='__EXCLUDE_MODULES')
         cd "${srcdir}/${_nv_pkg}/kernel"
         make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
 
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         cd "${srcdir}/${_nv_open_pkg}"
         MODULE_FLAGS+=(IGNORE_CC_MISMATCH=yes)
         CFLAGS= CXXFLAGS= LDFLAGS= make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
     fi
 
-    if [ -n "$_build_zfs" ]; then
+    if [ "$_build_zfs" = "yes" ]; then
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
@@ -745,11 +732,11 @@ _package-nvidia-open(){
 }
 
 pkgname=("$pkgbase")
-[ -n "$_build_debug" ] && pkgname+=("$pkgbase-dbg")
+[ "$_build_debug" = "yes" ] && pkgname+=("$pkgbase-dbg")
 pkgname+=("$pkgbase-headers")
-[ -n "$_build_zfs" ] && pkgname+=("$pkgbase-zfs")
-[ -n "$_build_nvidia" ] && pkgname+=("$pkgbase-nvidia")
-[ -n "$_build_nvidia_open" ] && pkgname+=("$pkgbase-nvidia-open")
+[ "$_build_zfs" = "yes" ] && pkgname+=("$pkgbase-zfs")
+[ "$_build_nvidia" = "yes" ] && pkgname+=("$pkgbase-nvidia")
+[ "$_build_nvidia_open" = "yes" ] && pkgname+=("$pkgbase-nvidia-open")
 for _p in "${pkgname[@]}"; do
     eval "package_$_p() {
     $(declare -f "_package${_p#$pkgbase}")

--- a/linux-cachyos-hardened/PKGBUILD
+++ b/linux-cachyos-hardened/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-_cachy_config=${_cachy_config-y}
+: "${_cachy_config:=y}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -20,25 +20,25 @@ _cachy_config=${_cachy_config-y}
 # 'eevdf' - select 'EEVDF Scheduler'
 # 'rt' - select EEVDF, but includes a series of realtime patches
 # 'rt-bore' - select Burst-Oriented Response Enhancer, but includes a series of realtime patches
-_cpusched=${_cpusched-hardened}
+: "${_cpusched:=hardened}"
 
 ### Tweak kernel options prior to a build via nconfig
-_makenconfig=${_makenconfig-}
+: "${_makenconfig:=}"
 
 ### Tweak kernel options prior to a build via menuconfig
-_makemenuconfig=${_makemenuconfig-}
+: "${_makemenuconfig:=}"
 
 ### Tweak kernel options prior to a build via xconfig
-_makexconfig=${_makexconfig-}
+: "${_makexconfig:=}"
 
 ### Tweak kernel options prior to a build via gconfig
-_makegconfig=${_makegconfig-}
+: "${_makegconfig:=}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-_NUMAdisable=${_NUMAdisable-}
+: "${_NUMAdisable:=}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,36 +48,36 @@ _NUMAdisable=${_NUMAdisable-}
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-_localmodcfg=${_localmodcfg-}
+: "${_localmodcfg:=}"
 
 # Path to the list of used modules
-_localmodcfg_path=${_localmodcfg_path-"$HOME/.config/modprobed.db"}
+: "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
 
 # Use the current kernel's .config file
 # Enabling this option will use the .config of the RUNNING kernel rather than
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-_use_current=${_use_current-}
+: "${_use_current:=}"
 
 ### Enable KBUILD_CFLAGS -O3
-_cc_harder=${_cc_harder-y}
+: "${_cc_harder:=y}"
 
 ### Set performance governor as default
-_per_gov=${_per_gov-}
+: "${_per_gov:=}"
 
 ### Enable TCP_CONG_BBR3
-_tcp_bbr3=${_tcp_bbr3-}
+: "${_tcp_bbr3:=}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
-_HZ_ticks=${_HZ_ticks-1000}
+: "${_HZ_ticks:=1000}"
 
 ## Choose between perodic, idle or full
 ### Full tickless can give higher performances in various cases but, depending on hardware, lower consistency.
-_tickrate=${_tickrate-full}
+: "${_tickrate:=full}"
 
 ## Choose between full(low-latency), voluntary or server
-_preempt=${_preempt-full}
+: "${_preempt:=full}"
 
 ### Transparent Hugepages
 # ATTENTION - one of two predefined values should be selected!
@@ -85,7 +85,7 @@ _preempt=${_preempt-full}
 # 'madvise' - madvise, prevent applications from allocating more memory resources than necessary
 # More infos here:
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/performance_tuning_guide/sect-red_hat_enterprise_linux-performance_tuning_guide-configuring_transparent_huge_pages
-_hugepage=${_hugepage-madvise}
+: "${_hugepage:=madvise}"
 
 # CPU compiler optimizations - Defaults to prompt at kernel config if left empty
 # AMD CPUs : "k8" "k8sse3" "k10" "barcelona" "bobcat" "jaguar" "bulldozer" "piledriver" "steamroller" "excavator" "zen" "zen2" "zen3" "zen4"
@@ -95,52 +95,52 @@ _hugepage=${_hugepage-madvise}
 # - "native_intel" (use compiler autodetection and will prompt for P6_NOPS - Selecting your arch manually in the list above is recommended instead of this option)
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 #
-_processor_opt=${_processor_opt-}
+: "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-_use_auto_optimization=${_use_auto_optimization-y}
+: "${_use_auto_optimization:=y}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
 # "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
 # "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
 # "none: disable LTO
-_use_llvm_lto=${_use_llvm_lto-none}
+: "${_use_llvm_lto:=none}"
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
 # y - enable -lto suffix
 # n - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-_use_lto_suffix=${_use_lto_suffix-y}
+: "${_use_lto_suffix:=y}"
 
 # Use suffix -gcc when requested by the user
 # This was added to facilitate https://github.com/CachyOS/linux-cachyos/issues/286
-_use_gcc_suffix=${_use_gcc_suffix-}
+: "${_use_gcc_suffix:=}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-_use_kcfi=${_use_kcfi-}
+: "${_use_kcfi:=}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-_build_zfs=${_build_zfs-}
+: "${_build_zfs:=}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-_build_nvidia=${_build_nvidia-}
+: "${_build_nvidia:=}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-_build_nvidia_open=${_build_nvidia_open-}
+: "${_build_nvidia_open:=}"
 
 # Build a debug package with non-stripped vmlinux
-_build_debug=${_build_debug-}
+: "${_build_debug:=}"
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {

--- a/linux-cachyos-hardened/PKGBUILD
+++ b/linux-cachyos-hardened/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-: "${_cachy_config:=y}"
+: "${_cachy_config:=yes}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -23,22 +23,22 @@
 : "${_cpusched:=hardened}"
 
 ### Tweak kernel options prior to a build via nconfig
-: "${_makenconfig:=}"
+: "${_makenconfig:=no}"
 
 ### Tweak kernel options prior to a build via menuconfig
-: "${_makemenuconfig:=}"
+: "${_makemenuconfig:=no}"
 
 ### Tweak kernel options prior to a build via xconfig
-: "${_makexconfig:=}"
+: "${_makexconfig:=no}"
 
 ### Tweak kernel options prior to a build via gconfig
-: "${_makegconfig:=}"
+: "${_makegconfig:=no}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-: "${_NUMAdisable:=}"
+: "${_NUMAdisable:=no}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,7 +48,7 @@
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-: "${_localmodcfg:=}"
+: "${_localmodcfg:=no}"
 
 # Path to the list of used modules
 : "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
@@ -58,16 +58,16 @@
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-: "${_use_current:=}"
+: "${_use_current:=no}"
 
 ### Enable KBUILD_CFLAGS -O3
-: "${_cc_harder:=y}"
+: "${_cc_harder:=yes}"
 
 ### Set performance governor as default
-: "${_per_gov:=}"
+: "${_per_gov:=no}"
 
 ### Enable TCP_CONG_BBR3
-: "${_tcp_bbr3:=}"
+: "${_tcp_bbr3:=no}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
 : "${_HZ_ticks:=1000}"
@@ -98,7 +98,7 @@
 : "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-: "${_use_auto_optimization:=y}"
+: "${_use_auto_optimization:=yes}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
@@ -109,38 +109,38 @@
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
-# y - enable -lto suffix
-# n - disable -lto suffix
+# yes - enable -lto suffix
+# no - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-: "${_use_lto_suffix:=y}"
+: "${_use_lto_suffix:=yes}"
 
 # Use suffix -gcc when requested by the user
 # This was added to facilitate https://github.com/CachyOS/linux-cachyos/issues/286
-: "${_use_gcc_suffix:=}"
+: "${_use_gcc_suffix:=no}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-: "${_use_kcfi:=}"
+: "${_use_kcfi:=no}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-: "${_build_zfs:=}"
+: "${_build_zfs:=no}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-: "${_build_nvidia:=}"
+: "${_build_nvidia:=no}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-: "${_build_nvidia_open:=}"
+: "${_build_nvidia_open:=no}"
 
 # Build a debug package with non-stripped vmlinux
-: "${_build_debug:=}"
+: "${_build_debug:=no}"
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
@@ -148,9 +148,10 @@ _is_lto_kernel() {
     return $?
 }
 
-if _is_lto_kernel && [ "$_use_lto_suffix" = "y"  ]; then
-    _pkgsuffix="cachyos-${_cpusched}-lto"
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "y" ]; then
+
+if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
+     _pkgsuffix="cachyos-${_cpusched}-lto"
+elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-${_cpusched}-gcc"
 else
     _pkgsuffix="cachyos-${_cpusched}"
@@ -216,18 +217,18 @@ if [[ "$_cpusched" = "rt" || "$_cpusched" = "rt-bore" ]]; then
 fi
 
 # ZFS support
-if [ -n "$_build_zfs" ]; then
+if [ "$_build_zfs" = "yes" ]; then
     makedepends+=(git)
     source+=("git+https://github.com/cachyos/zfs.git#commit=e65f69e41f4a276d7d0d1800a2878308a0ba84a6")
 fi
 
 # NVIDIA pre-build module support
-if [ -n "$_build_nvidia" ]; then
+if [ "$_build_nvidia" = "yes" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch")
 fi
 
-if [ -n "$_build_nvidia_open" ]; then
+if [ "$_build_nvidia_open" = "yes" ]; then
     source+=("nvidia-open-${_nv_ver}.tar.gz::https://github.com/NVIDIA/open-gpu-kernel-modules/archive/refs/tags/${_nv_ver}.tar.gz"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch"
              "${_patchsource}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch"
@@ -294,19 +295,17 @@ prepare() {
     fi
 
     ### Use autooptimization
-    if [ -n "$_use_auto_optimization" ]; then
+    if [ "$_use_auto_optimization" = "yes" ]; then
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
     ### Selecting CachyOS config
-    if [ -n "$_cachy_config" ]; then
+    if [ "$_cachy_config" = "yes" ]; then
         echo "Enabling CachyOS config..."
         scripts/config -e CACHY
     fi
 
     ### Selecting the CPU scheduler
-    [ -z "$_cpusched" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_cpusched" in
         cachyos|bore|hardened) scripts/config -e SCHED_BORE;;
         bmq) scripts/config -e SCHED_ALT -e SCHED_BMQ;;
@@ -319,14 +318,12 @@ prepare() {
     echo "Selecting ${_cpusched^^} CPU scheduler..."
 
     ### Enable KCFI
-    if [ -n "$_use_kcfi" ]; then
+    if [ "$_use_kcfi" = "yes" ]; then
         echo "Enabling kCFI"
         scripts/config -e ARCH_SUPPORTS_CFI_CLANG -e CFI_CLANG -e CFI_AUTO_DEFAULT
     fi
 
     ### Select LLVM level
-    [ -z "$_use_llvm_lto" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_use_llvm_lto" in
         thin) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -d LTO_CLANG_FULL -e LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
         full) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -e LTO_CLANG_FULL -d LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
@@ -337,8 +334,6 @@ prepare() {
     echo "Selecting '$_use_llvm_lto' LLVM level..."
 
     ### Select tick rate
-    [ -z "$_HZ_ticks" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_HZ_ticks" in
         100|250|500|600|625|750|1000)
             scripts/config -d HZ_300 -e "HZ_${_HZ_ticks}" --set-val HZ "${_HZ_ticks}";;
@@ -351,7 +346,7 @@ prepare() {
     echo "Setting tick rate to ${_HZ_ticks}Hz..."
 
     ### Disable NUMA
-    if [ -n "$_NUMAdisable" ]; then
+    if [ "$_NUMAdisable" = "yes" ]; then
         echo "Disabling NUMA from kernel config..."
         scripts/config -d NUMA \
             -d AMD_NUMA \
@@ -369,15 +364,13 @@ prepare() {
     fi
 
     ### Select performance governor
-    if [ -n "$_per_gov" ]; then
+    if [ "$_per_gov" = "yes" ]; then
         echo "Setting performance governor..."
         scripts/config -d CPU_FREQ_DEFAULT_GOV_SCHEDUTIL \
             -e CPU_FREQ_DEFAULT_GOV_PERFORMANCE
     fi
 
     ### Select tick type
-    [ -z "$_tickrate" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_tickrate" in
         perodic) scripts/config -d NO_HZ_IDLE -d NO_HZ_FULL -d NO_HZ -d NO_HZ_COMMON -e HZ_PERIODIC;;
         idle) scripts/config -d HZ_PERIODIC -d NO_HZ_FULL -e NO_HZ_IDLE  -e NO_HZ -e NO_HZ_COMMON;;
@@ -391,8 +384,6 @@ prepare() {
 
     # We should not set up the PREEMPT for RT kernels
     if [[ "$_cpusched" != "rt" || "$_cpusched" != "rt-bore" ]]; then
-        [ -z "$_preempt" ] && _die "The value is empty. Choose the correct one again."
-
         case "$_preempt" in
             full) scripts/config -e PREEMPT_BUILD -d PREEMPT_NONE -d PREEMPT_VOLUNTARY -e PREEMPT -e PREEMPT_COUNT -e PREEMPTION -e PREEMPT_DYNAMIC;;
             voluntary) scripts/config -e PREEMPT_BUILD -d PREEMPT_NONE -e PREEMPT_VOLUNTARY -d PREEMPT -e PREEMPT_COUNT -e PREEMPTION -d PREEMPT_DYNAMIC;;
@@ -404,7 +395,7 @@ prepare() {
     fi
 
     ### Enable O3
-    if [ -n "$_cc_harder" ] && [ -z "$_cc_size" ]; then
+    if [ "$_cc_harder" = "yes" ]; then
         echo "Enabling KBUILD_CFLAGS -O3..."
         scripts/config -d CC_OPTIMIZE_FOR_PERFORMANCE \
             -e CC_OPTIMIZE_FOR_PERFORMANCE_O3
@@ -427,7 +418,7 @@ prepare() {
     fi
 
     ### Enable bbr3
-    if [ -n "$_tcp_bbr3" ]; then
+    if [ "$_tcp_bbr3" = "yes" ]; then
         echo "Disabling TCP_CONG_CUBIC..."
         scripts/config -m TCP_CONG_CUBIC \
             -d DEFAULT_CUBIC \
@@ -441,8 +432,6 @@ prepare() {
     fi
 
     ### Select THP
-    [ -z "$_hugepage" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_hugepage" in
         always) scripts/config -d TRANSPARENT_HUGEPAGE_MADVISE -e TRANSPARENT_HUGEPAGE_ALWAYS;;
         madvise) scripts/config -d TRANSPARENT_HUGEPAGE_ALWAYS -e TRANSPARENT_HUGEPAGE_MADVISE;;
@@ -456,7 +445,7 @@ prepare() {
 
     ### Optionally use running kernel's config
     # code originally by nous; http://aur.archlinux.org/packages.php?ID=40191
-    if [ -n "$_use_current" ]; then
+    if [ "$_use_current" = "yes" ]; then
         if [[ -s /proc/config.gz ]]; then
             echo "Extracting config from /proc/config.gz..."
             # modprobe configs
@@ -469,10 +458,9 @@ prepare() {
         fi
     fi
 
-
     ### Optionally load needed modules for the make localmodconfig
     # See https://aur.archlinux.org/packages/modprobed-db
-    if [ -n "$_localmodcfg" ]; then
+    if [ "$_localmodcfg" = "yes" ]; then
         if [ -e "$_localmodcfg_path" ]; then
             echo "Running Steven Rostedt's make localmodconfig now"
             make "${BUILD_FLAGS[@]}" LSMOD="${_localmodcfg_path}" localmodconfig
@@ -492,23 +480,23 @@ prepare() {
     echo "Prepared $pkgbase version $(<version)"
 
     ### Running make nconfig
-    [[ -z "$_makenconfig" ]] ||  make "${BUILD_FLAGS[@]}" nconfig
+    [ "$_makenconfig" = "yes" ] && make "${BUILD_FLAGS[@]}" nconfig
 
     ### Running make menuconfig
-    [[ -z "$_makemenuconfig" ]] ||  make "${BUILD_FLAGS[@]}" menuconfig
+    [ "$_makemenuconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" menuconfig
 
     ### Running make xconfig
-    [[ -z "$_makexconfig" ]] ||  make "${BUILD_FLAGS[@]}" xconfig
+    [ "$_makexconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" xconfig
 
     ### Running make gconfig
-    [[ -z "$_makegconfig" ]] ||  make "${BUILD_FLAGS[@]}" gconfig
+    [ "$_makegconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" gconfig
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
     local basedir="$(dirname "$(readlink "${srcdir}/config")")"
     cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
 
@@ -516,7 +504,7 @@ prepare() {
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_pkg}/kernel"
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_open_pkg}/kernel-open"
         # Fix for Zen5 error print in dmesg
         patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch" -d "${srcdir}/${_nv_open_pkg}"
@@ -539,20 +527,20 @@ build() {
        SYSSRC="${srcdir}/${_srcname}"
        SYSOUT="${srcdir}/${_srcname}"
     )
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         MODULE_FLAGS+=(NV_EXCLUDE_BUILD_MODULES='__EXCLUDE_MODULES')
         cd "${srcdir}/${_nv_pkg}/kernel"
         make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
 
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         cd "${srcdir}/${_nv_open_pkg}"
         MODULE_FLAGS+=(IGNORE_CC_MISMATCH=yes)
         CFLAGS= CXXFLAGS= LDFLAGS= make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
     fi
 
-    if [ -n "$_build_zfs" ]; then
+    if [ "$_build_zfs" = "yes" ]; then
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
@@ -743,11 +731,11 @@ _package-nvidia-open(){
 }
 
 pkgname=("$pkgbase")
-[ -n "$_build_debug" ] && pkgname+=("$pkgbase-dbg")
+[ "$_build_debug" = "yes" ] && pkgname+=("$pkgbase-dbg")
 pkgname+=("$pkgbase-headers")
-[ -n "$_build_zfs" ] && pkgname+=("$pkgbase-zfs")
-[ -n "$_build_nvidia" ] && pkgname+=("$pkgbase-nvidia")
-[ -n "$_build_nvidia_open" ] && pkgname+=("$pkgbase-nvidia-open")
+[ "$_build_zfs" = "yes" ] && pkgname+=("$pkgbase-zfs")
+[ "$_build_nvidia" = "yes" ] && pkgname+=("$pkgbase-nvidia")
+[ "$_build_nvidia_open" = "yes" ] && pkgname+=("$pkgbase-nvidia-open")
 for _p in "${pkgname[@]}"; do
     eval "package_$_p() {
     $(declare -f "_package${_p#$pkgbase}")

--- a/linux-cachyos-lts/PKGBUILD
+++ b/linux-cachyos-lts/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-_cachy_config=${_cachy_config-y}
+: "${_cachy_config:=y}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -20,25 +20,25 @@ _cachy_config=${_cachy_config-y}
 # 'rt' - select EEVDF, but includes a series of realtime patches
 # 'rt-bore' - select Burst-Oriented Response Enhancer, but includes a series of realtime patches
 # 'sched-ext' - select 'sched-ext' Scheduler, based on EEVDF
-_cpusched=${_cpusched-cachyos}
+: "${_cpusched:=cachyos}"
 
 ### Tweak kernel options prior to a build via nconfig
-_makenconfig=${_makenconfig-}
+: "${_makenconfig:=}"
 
 ### Tweak kernel options prior to a build via menuconfig
-_makemenuconfig=${_makemenuconfig-}
+: "${_makemenuconfig:=}"
 
 ### Tweak kernel options prior to a build via xconfig
-_makexconfig=${_makexconfig-}
+: "${_makexconfig:=}"
 
 ### Tweak kernel options prior to a build via gconfig
-_makegconfig=${_makegconfig-}
+: "${_makegconfig:=}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-_NUMAdisable=${_NUMAdisable-}
+: "${_NUMAdisable:=}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,53 +48,53 @@ _NUMAdisable=${_NUMAdisable-}
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-_localmodcfg=${_localmodcfg-}
+: "${_localmodcfg:=}"
 
 # Path to the list of used modules
-_localmodcfg_path=${_localmodcfg_path-"$HOME/.config/modprobed.db"}
+: "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
 
 # Use the current kernel's .config file
 # Enabling this option will use the .config of the RUNNING kernel rather than
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-_use_current=${_use_current-}
+: "${_use_current:=}"
 
 ### Enable KBUILD_CFLAGS -O3
-_cc_harder=${_cc_harder-y}
+: "${_cc_harder:=y}"
 
 ### Set this to your number of threads you have in your machine otherwise it will default to 320
-_nr_cpus=${_nr_cpus-}
+: "${_nr_cpus:=}"
 
 ### Set performance governor as default
-_per_gov=${_per_gov-}
+: "${_per_gov:=}"
 
 ### Enable TCP_CONG_BBR3
-_tcp_bbr3=${_tcp_bbr3-}
+: "${_tcp_bbr3:=}"
 
 ### Running with a 1000HZ, 750Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
-_HZ_ticks=${_HZ_ticks-1000}
+: "${_HZ_ticks:=1000}"
 
 ## Choose between perodic, idle or full
 ### Full tickless can give higher performances in various cases but, depending on hardware, lower consistency.
-_tickrate=${_tickrate-full}
+: "${_tickrate:=full}"
 
 ## Choose between full(low-latency), voluntary or server
-_preempt=${_preempt-full}
+: "${_preempt:=full}"
 
 ### Enable multigenerational LRU
 # ATTENTION - one of three predefined values should be selected!
 # 'standard' - enable multigenerational LRU
 # 'stats' - enable multigenerational LRU with stats
 # 'none' - disable multigenerational LRU
-_lru_config=${_lru_config-standard}
+: "${_lru_config:=standard}"
 
 ### Enable per-VMA locking
 # ATTENTION - one of three predefined values should be selected!
 # 'standard' - enable per-VMA locking
 # 'stats' - enable per-VMA locking with stats
 # 'none' - disable per-VMA locking
-_vma_config=${_vma_config-standard}
+: "${_vma_config:=standard}"
 
 ### Transparent Hugepages
 # ATTENTION - one of two predefined values should be selected!
@@ -102,7 +102,7 @@ _vma_config=${_vma_config-standard}
 # 'madvise' - madvise, prevent applications from allocating more memory resources than necessary
 # More infos here:
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/performance_tuning_guide/sect-red_hat_enterprise_linux-performance_tuning_guide-configuring_transparent_huge_pages
-_hugepage=${_hugepage-always}
+: "${_hugepage:=always}"
 
 ## Enable DAMON
 _damon=${_damon-}
@@ -116,30 +116,30 @@ _damon=${_damon-}
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 #
 # Or use the _use_auto_optimization with _use_auto_optimization=y
-_processor_opt=${_processor_opt-}
+: "${_processor_opt:=}"
 
-_use_auto_optimization=${_use_auto_optimization-y}
+: "${_use_auto_optimization:=y}"
 
 # disable debug to lower the size of the kernel
-_disable_debug=${_disable_debug-}
+: "${_disable_debug:=}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
 # "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
 # "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
 # "none: disable LTO
-_use_llvm_lto=${_use_llvm_lto-none}
+: "${_use_llvm_lto:=none}"
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
 # y - enable -lto suffix
 # n - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-_use_lto_suffix=${_use_lto_suffix-y}
+: "${_use_lto_suffix:=y}"
 
 # Use suffix -gcc when requested by the user
 # This was added to facilitate https://github.com/CachyOS/linux-cachyos/issues/286
-_use_gcc_suffix=${_use_gcc_suffix-}
+: "${_use_gcc_suffix:=}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
@@ -147,27 +147,27 @@ _use_gcc_suffix=${_use_gcc_suffix-}
 # alter function references to point to a jump table, and won't break
 # function address equality.
 # ATTENTION!: kCFI is only available in llvm 16
-_use_kcfi=${_use_kcfi-}
+: "${_use_kcfi:=}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-_build_zfs=${_build_zfs-}
+: "${_build_zfs:=}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-_build_nvidia=${_build_nvidia-}
+: "${_build_nvidia:=}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-_build_nvidia_open=${_build_nvidia_open-}
+: "${_build_nvidia_open:=}"
 
 # Enable bcachefs
-_bcachefs=${_bcachefs-}
+: "${_bcachefs:=}"
 
 # Build a debug package with non-stripped vmlinux
-_build_debug=${_build_debug-}
+: "${_build_debug:=}"
 
 if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] && [ "$_use_lto_suffix" = "y"  ]; then
     _pkgsuffix="cachyos-lts-lto"

--- a/linux-cachyos-lts/PKGBUILD
+++ b/linux-cachyos-lts/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-: "${_cachy_config:=y}"
+: "${_cachy_config:=yes}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -23,22 +23,22 @@
 : "${_cpusched:=cachyos}"
 
 ### Tweak kernel options prior to a build via nconfig
-: "${_makenconfig:=}"
+: "${_makenconfig:=no}"
 
 ### Tweak kernel options prior to a build via menuconfig
-: "${_makemenuconfig:=}"
+: "${_makemenuconfig:=no}"
 
 ### Tweak kernel options prior to a build via xconfig
-: "${_makexconfig:=}"
+: "${_makexconfig:=no}"
 
 ### Tweak kernel options prior to a build via gconfig
-: "${_makegconfig:=}"
+: "${_makegconfig:=no}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-: "${_NUMAdisable:=}"
+: "${_NUMAdisable:=no}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,7 +48,7 @@
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-: "${_localmodcfg:=}"
+: "${_localmodcfg:=no}"
 
 # Path to the list of used modules
 : "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
@@ -58,19 +58,19 @@
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-: "${_use_current:=}"
+: "${_use_current:=no}"
 
 ### Enable KBUILD_CFLAGS -O3
-: "${_cc_harder:=y}"
+: "${_cc_harder:=yes}"
 
 ### Set this to your number of threads you have in your machine otherwise it will default to 320
-: "${_nr_cpus:=}"
+: "${_nr_cpus:=320}"
 
 ### Set performance governor as default
-: "${_per_gov:=}"
+: "${_per_gov:=no}"
 
 ### Enable TCP_CONG_BBR3
-: "${_tcp_bbr3:=}"
+: "${_tcp_bbr3:=no}"
 
 ### Running with a 1000HZ, 750Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
 : "${_HZ_ticks:=1000}"
@@ -105,7 +105,7 @@
 : "${_hugepage:=always}"
 
 ## Enable DAMON
-_damon=${_damon-}
+: "${_damon:=no}"
 
 # CPU compiler optimizations - Defaults to prompt at kernel config if left empty
 # AMD CPUs : "k8" "k8sse3" "k10" "barcelona" "bobcat" "jaguar" "bulldozer" "piledriver" "steamroller" "excavator" "zen" "zen2" "zen3" "zen4"
@@ -118,10 +118,10 @@ _damon=${_damon-}
 # Or use the _use_auto_optimization with _use_auto_optimization=y
 : "${_processor_opt:=}"
 
-: "${_use_auto_optimization:=y}"
+: "${_use_auto_optimization:=yes}"
 
 # disable debug to lower the size of the kernel
-: "${_disable_debug:=}"
+: "${_disable_debug:=no}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
@@ -132,14 +132,14 @@ _damon=${_damon-}
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
-# y - enable -lto suffix
-# n - disable -lto suffix
+# yes - enable -lto suffix
+# no - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-: "${_use_lto_suffix:=y}"
+: "${_use_lto_suffix:=yes}"
 
 # Use suffix -gcc when requested by the user
 # This was added to facilitate https://github.com/CachyOS/linux-cachyos/issues/286
-: "${_use_gcc_suffix:=}"
+: "${_use_gcc_suffix:=no}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
@@ -147,31 +147,31 @@ _damon=${_damon-}
 # alter function references to point to a jump table, and won't break
 # function address equality.
 # ATTENTION!: kCFI is only available in llvm 16
-: "${_use_kcfi:=}"
+: "${_use_kcfi:=no}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-: "${_build_zfs:=}"
+: "${_build_zfs:=no}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-: "${_build_nvidia:=}"
+: "${_build_nvidia:=no}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-: "${_build_nvidia_open:=}"
+: "${_build_nvidia_open:=no}"
 
 # Enable bcachefs
-: "${_bcachefs:=}"
+: "${_bcachefs:=no}"
 
 # Build a debug package with non-stripped vmlinux
-: "${_build_debug:=}"
+: "${_build_debug:=no}"
 
-if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] && [ "$_use_lto_suffix" = "y"  ]; then
+if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix="cachyos-lts-lto"
-elif [ "$_use_llvm_lto" = "none" ]  && [ -z "$_use_kcfi" ] && [ "$_use_gcc_suffix" = "y" ]; then
+elif [ "$_use_llvm_lto" = "none" ]  && [ "$_use_kcfi" != "yes" ] && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-lts-gcc"
 else
     _pkgsuffix="cachyos-lts"
@@ -220,7 +220,7 @@ source=(
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
-if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ -n "$_use_kcfi" ]; then
+if [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full" ]] || [ "$_use_kcfi" = "yes" ]; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(
@@ -237,18 +237,18 @@ if [[ "$_cpusched" = "rt" || "$_cpusched" = "rt-bore" ]]; then
 fi
 
 # ZFS support
-if [ -n "$_build_zfs" ]; then
+if [ "$_build_zfs" = "yes" ]; then
     makedepends+=(git)
     source+=("git+https://github.com/cachyos/zfs.git#commit=e65f69e41f4a276d7d0d1800a2878308a0ba84a6")
 fi
 
 # NVIDIA pre-build module support
-if [ -n "$_build_nvidia" ]; then
+if [ "$_build_nvidia" = "yes" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch")
 fi
 
-if [ -n "$_build_nvidia_open" ]; then
+if [ "$_build_nvidia_open" = "yes" ]; then
     source+=("nvidia-open-${_nv_ver}.tar.gz::https://github.com/NVIDIA/open-gpu-kernel-modules/archive/refs/tags/${_nv_ver}.tar.gz"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch"
              "${_patchsource}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch"
@@ -277,7 +277,7 @@ case "$_cpusched" in
 esac
 
 ## bcachefs Support
-if [ -n "$_bcachefs" ]; then
+if [ "$_bcachefs" = "yes" ]; then
     source+=("${_patchsource}/misc/0001-bcachefs.patch")
 fi
 
@@ -326,19 +326,17 @@ prepare() {
     fi
 
     ### Use autooptimization
-    if [ -n "$_use_auto_optimization" ]; then
+    if [ "$_use_auto_optimization" = "yes" ]; then
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
     ### Selecting CachyOS config
-    if [ -n "$_cachy_config" ]; then
+    if [ "$_cachy_config" = "yes" ]; then
         echo "Enabling CachyOS config..."
         scripts/config -e CACHY
     fi
 
     ### Selecting the CPU scheduler
-    [ -z "$_cpusched" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_cpusched" in
         bore|hardened|cachyos) scripts/config -e SCHED_BORE;;
         eevdf) ;;
@@ -351,15 +349,13 @@ prepare() {
     echo "Selecting ${_cpusched^^} CPU scheduler..."
 
     ### Enable KCFI
-    if [ -n "$_use_kcfi" ]; then
+    if [ "$_use_kcfi" = "yes" ]; then
         echo "Enabling kCFI"
         scripts/config -e ARCH_SUPPORTS_CFI_CLANG \
             -e CFI_CLANG
     fi
 
     ### Select LLVM level
-    [ -z "$_use_llvm_lto" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_use_llvm_lto" in
         thin) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -d LTO_CLANG_FULL -e LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
         full) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -e LTO_CLANG_FULL -d LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
@@ -370,8 +366,6 @@ prepare() {
     echo "Selecting '$_use_llvm_lto' LLVM level..."
 
     ### Select tick rate
-    [ -z "$_HZ_ticks" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_HZ_ticks" in
         100|250|500|600|750|1000)
             scripts/config -d HZ_300 -e "HZ_${_HZ_ticks}" --set-val HZ "${_HZ_ticks}";;
@@ -384,7 +378,7 @@ prepare() {
     echo "Setting tick rate to ${_HZ_ticks}Hz..."
 
     ### Disable NUMA
-    if [ -n "$_NUMAdisable" ]; then
+    if [ "$_NUMAdisable" = "yes" ]; then
         echo "Disabling NUMA from kernel config..."
         scripts/config -d NUMA \
             -d AMD_NUMA \
@@ -403,25 +397,20 @@ prepare() {
 
     ### Setting NR_CPUS
     if [[ "$_nr_cpus" -ge 2 && "$_nr_cpus" -le 512 ]]; then
-        echo "Setting custom NR_CPUS..."
+        echo "Setting NR_CPUS..."
         scripts/config --set-val NR_CPUS "$_nr_cpus"
-    elif [ -z "$_nr_cpus" ]; then
-        echo "Setting default NR_CPUS..."
-        scripts/config --set-val NR_CPUS 320
     else
         _die "The value '$_nr_cpus' is invalid. Please select a numerical value from 2 to 512..."
     fi
 
     ### Select performance governor
-    if [ -n "$_per_gov" ]; then
+    if [ "$_per_gov" = "yes" ]; then
         echo "Setting performance governor..."
         scripts/config -d CPU_FREQ_DEFAULT_GOV_SCHEDUTIL \
             -e CPU_FREQ_DEFAULT_GOV_PERFORMANCE
     fi
 
     ### Select tick type
-    [ -z "$_tickrate" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_tickrate" in
         perodic) scripts/config -d NO_HZ_IDLE -d NO_HZ_FULL -d NO_HZ -d NO_HZ_COMMON -e HZ_PERIODIC;;
         idle) scripts/config -d HZ_PERIODIC -d NO_HZ_FULL -e NO_HZ_IDLE  -e NO_HZ -e NO_HZ_COMMON;;
@@ -435,8 +424,6 @@ prepare() {
 
     # We should not set up the PREEMPT for RT kernels
     if [[ "$_cpusched" != "rt" || "$_cpusched" != "rt-bore" ]]; then
-        [ -z "$_preempt" ] && _die "The value is empty. Choose the correct one again."
-
         case "$_preempt" in
             full) scripts/config -e PREEMPT_BUILD -d PREEMPT_NONE -d PREEMPT_VOLUNTARY -e PREEMPT -e PREEMPT_COUNT -e PREEMPTION -e PREEMPT_DYNAMIC;;
             voluntary) scripts/config -e PREEMPT_BUILD -d PREEMPT_NONE -e PREEMPT_VOLUNTARY -d PREEMPT -e PREEMPT_COUNT -e PREEMPTION -d PREEMPT_DYNAMIC;;
@@ -448,7 +435,7 @@ prepare() {
     fi
 
     ### Enable O3
-    if [ -n "$_cc_harder" ] && [ -z "$_cc_size" ]; then
+    if [ "$_cc_harder" = "yes" ]; then
         echo "Enabling KBUILD_CFLAGS -O3..."
         scripts/config -d CC_OPTIMIZE_FOR_PERFORMANCE \
             -e CC_OPTIMIZE_FOR_PERFORMANCE_O3
@@ -471,7 +458,7 @@ prepare() {
     fi
 
     ### Enable bbr3
-    if [ -n "$_tcp_bbr3" ]; then
+    if [ "$_tcp_bbr3" = "yes" ]; then
         echo "Disabling TCP_CONG_CUBIC..."
         scripts/config -m TCP_CONG_CUBIC \
             -d DEFAULT_CUBIC \
@@ -485,8 +472,6 @@ prepare() {
     fi
 
     ### Select LRU config
-    [ -z "$_lru_config" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_lru_config" in
         standard) scripts/config -e LRU_GEN -e LRU_GEN_ENABLED -d LRU_GEN_STATS;;
         stats) scripts/config -e LRU_GEN -e LRU_GEN_ENABLED -e LRU_GEN_STATS;;
@@ -497,8 +482,6 @@ prepare() {
     echo "Selecting '$_lru_config' LRU_GEN config..."
 
     ### Select VMA config
-    [ -z "$_vma_config" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_vma_config" in
         standard) scripts/config -e PER_VMA_LOCK -d PER_VMA_LOCK_STATS;;
         stats) scripts/config -e PER_VMA_LOCK -e PER_VMA_LOCK_STATS;;
@@ -509,8 +492,6 @@ prepare() {
     echo "Selecting '$_vma_config' PER_VMA_LOCK config..."
 
     ### Select THP
-    [ -z "$_hugepage" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_hugepage" in
         always) scripts/config -d TRANSPARENT_HUGEPAGE_MADVISE -e TRANSPARENT_HUGEPAGE_ALWAYS;;
         madvise) scripts/config -d TRANSPARENT_HUGEPAGE_ALWAYS -e TRANSPARENT_HUGEPAGE_MADVISE;;
@@ -520,7 +501,7 @@ prepare() {
     echo "Selecting '$_hugepage' TRANSPARENT_HUGEPAGE config..."
 
     ### Enable DAMON
-    if [ -n "$_damon" ]; then
+    if [ "$_damon" = "yes" ]; then
         echo "Enabling DAMON..."
         scripts/config -e DAMON \
             -e DAMON_VADDR \
@@ -536,7 +517,7 @@ prepare() {
     ### Disable DEBUG
     # Doesn't work with sched-ext
     # More infos here: https://github.com/CachyOS/linux-cachyos/issues/187
-    if [[ "$_cpusched" != "sched-ext" &&  -n "$_disable_debug" ]]; then
+    if [[ "$_cpusched" != "sched-ext" && "$_disable_debug" = "yes" ]]; then
         scripts/config -d DEBUG_INFO \
             -d DEBUG_INFO_BTF \
             -d DEBUG_INFO_DWARF4 \
@@ -558,7 +539,7 @@ prepare() {
 
     ### Optionally use running kernel's config
     # code originally by nous; http://aur.archlinux.org/packages.php?ID=40191
-    if [ -n "$_use_current" ]; then
+    if [ "$_use_current" = "yes" ]; then
         if [[ -s /proc/config.gz ]]; then
             echo "Extracting config from /proc/config.gz..."
             # modprobe configs
@@ -571,10 +552,9 @@ prepare() {
         fi
     fi
 
-
     ### Optionally load needed modules for the make localmodconfig
     # See https://aur.archlinux.org/packages/modprobed-db
-    if [ -n "$_localmodcfg" ]; then
+    if [ "$_localmodcfg" = "yes" ]; then
         if [ -e "$_localmodcfg_path" ]; then
             echo "Running Steven Rostedt's make localmodconfig now"
             make "${BUILD_FLAGS[@]}" LSMOD="${_localmodcfg_path}" localmodconfig
@@ -594,23 +574,23 @@ prepare() {
     echo "Prepared $pkgbase version $(<version)"
 
     ### Running make nconfig
-    [[ -z "$_makenconfig" ]] ||  make "${BUILD_FLAGS[@]}" nconfig
+    [ "$_makenconfig" = "yes" ] && make "${BUILD_FLAGS[@]}" nconfig
 
     ### Running make menuconfig
-    [[ -z "$_makemenuconfig" ]] ||  make "${BUILD_FLAGS[@]}" menuconfig
+    [ "$_makemenuconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" menuconfig
 
     ### Running make xconfig
-    [[ -z "$_makexconfig" ]] ||  make "${BUILD_FLAGS[@]}" xconfig
+    [ "$_makexconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" xconfig
 
     ### Running make gconfig
-    [[ -z "$_makegconfig" ]] ||  make "${BUILD_FLAGS[@]}" gconfig
+    [ "$_makegconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" gconfig
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
     local basedir="$(dirname "$(readlink "${srcdir}/config")")"
     cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
 
@@ -618,7 +598,7 @@ prepare() {
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_pkg}/kernel"
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_open_pkg}/kernel-open"
         # Fix for https://bugs.archlinux.org/task/74886
         patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0003-Add-IBT-Support.patch" -d "${srcdir}/${_nv_open_pkg}"
@@ -642,20 +622,20 @@ build() {
        SYSSRC="${srcdir}/${_srcname}"
        SYSOUT="${srcdir}/${_srcname}"
     )
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         MODULE_FLAGS+=(NV_EXCLUDE_BUILD_MODULES='__EXCLUDE_MODULES')
         cd "${srcdir}/${_nv_pkg}/kernel"
         make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
 
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         cd "${srcdir}/${_nv_open_pkg}"
         MODULE_FLAGS+=(IGNORE_CC_MISMATCH=yes)
         CFLAGS= CXXFLAGS= LDFLAGS= make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
     fi
 
-    if [ -n "$_build_zfs" ]; then
+    if [ "$_build_zfs" = "yes" ]; then
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
@@ -846,11 +826,11 @@ _package-nvidia-open(){
 }
 
 pkgname=("$pkgbase")
-[ -n "$_build_debug" ] && pkgname+=("$pkgbase-dbg")
+[ "$_build_debug" = "yes" ] && pkgname+=("$pkgbase-dbg")
 pkgname+=("$pkgbase-headers")
-[ -n "$_build_zfs" ] && pkgname+=("$pkgbase-zfs")
-[ -n "$_build_nvidia" ] && pkgname+=("$pkgbase-nvidia")
-[ -n "$_build_nvidia_open" ] && pkgname+=("$pkgbase-nvidia-open")
+[ "$_build_zfs" = "yes" ] && pkgname+=("$pkgbase-zfs")
+[ "$_build_nvidia" = "yes" ] && pkgname+=("$pkgbase-nvidia")
+[ "$_build_nvidia_open" = "yes" ] && pkgname+=("$pkgbase-nvidia-open")
 for _p in "${pkgname[@]}"; do
     eval "package_$_p() {
     $(declare -f "_package${_p#$pkgbase}")

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-: "${_cachy_config:=y}"
+: "${_cachy_config:=yes}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -23,22 +23,22 @@
 : "${_cpusched:=cachyos}"
 
 ### Tweak kernel options prior to a build via nconfig
-: "${_makenconfig:=}"
+: "${_makenconfig:=no}"
 
 ### Tweak kernel options prior to a build via menuconfig
-: "${_makemenuconfig:=}"
+: "${_makemenuconfig:=no}"
 
 ### Tweak kernel options prior to a build via xconfig
-: "${_makexconfig:=}"
+: "${_makexconfig:=no}"
 
 ### Tweak kernel options prior to a build via gconfig
-: "${_makegconfig:=}"
+: "${_makegconfig:=no}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-: "${_NUMAdisable:=}"
+: "${_NUMAdisable:=no}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,7 +48,7 @@
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-: "${_localmodcfg:=}"
+: "${_localmodcfg:=no}"
 
 # Path to the list of used modules
 : "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
@@ -58,16 +58,16 @@
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-: "${_use_current:=}"
+: "${_use_current:=no}"
 
 ### Enable KBUILD_CFLAGS -O3
-: "${_cc_harder:=y}"
+: "${_cc_harder:=yes}"
 
 ### Set performance governor as default
-: "${_per_gov:=}"
+: "${_per_gov:=no}"
 
 ### Enable TCP_CONG_BBR3
-: "${_tcp_bbr3:=}"
+: "${_tcp_bbr3:=no}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
 : "${_HZ_ticks:=1000}"
@@ -98,7 +98,7 @@
 : "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-: "${_use_auto_optimization:=y}"
+: "${_use_auto_optimization:=yes}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
@@ -108,48 +108,48 @@
 : "${_use_llvm_lto:=thin}"
 
 # Use suffix -lto only when requested by the user
-# y - enable -lto suffix
-# n - disable -lto suffix
+# yes - enable -lto suffix
+# no - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-: "${_use_lto_suffix:=}"
+: "${_use_lto_suffix:=no}"
 
 # Use suffix -gcc when requested by the user
 # Enabled by default to show the difference between LTO kernels and GCC kernels
-: "${_use_gcc_suffix:=y}"
+: "${_use_gcc_suffix:=yes}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-: "${_use_kcfi:=}"
+: "${_use_kcfi:=no}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-: "${_build_zfs:=}"
+: "${_build_zfs:=no}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-: "${_build_nvidia:=}"
+: "${_build_nvidia:=no}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-: "${_build_nvidia_open:=}"
+: "${_build_nvidia_open:=no}"
 
 # Build a debug package with non-stripped vmlinux
-: "${_build_debug:=}"
+: "${_build_debug:=no}"
 
 # Enable AUTOFDO_CLANG for the first compilation to create a kernel, which can be used for profiling
 # Workflow:
 # https://cachyos.org/blog/2411-kernel-autofdo/
-# 1. Compile Kernel with _autofdo=y and _build_debug=y
+# 1. Compile Kernel with _autofdo=yes and _build_debug=yes
 # 2. Boot the kernel in QEMU or on your system, see Workload
 # 3. Profile the kernel and convert the profile, see Generating the Profile for AutoFDO
 # 4. Put the profile into the sourcedir
 # 5. Run kernel build again with the _autofdo_profile_name path to profile specified
-: "${_autofdo:=}"
+: "${_autofdo:=no}"
 
 # Name for the AutoFDO profile
 : "${_autofdo_profile_name:=}"
@@ -162,10 +162,10 @@
 # create_llvm_prof --binary=/usr/src/debug/linux-cachyos-rc/vmlinux --profile=propeller.data --format=propeller --propeller_output_module_name --out=propeller_cc_profile.txt --propeller_symorder=propeller_ld_profile.txt
 # 4. Place the propeller_cc_profile.txt and propeller_ld_profile.txt into the srcdir
 # 5. Enable _propeller_prefix
-_propeller=${_propeller-}
+: "${_propeller:=no}"
 
 # Enable this after the profiles have been generated
-_propeller_profiles=${_propeller_profiles-}
+: "${_propeller_profiles:=no}"
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
@@ -173,9 +173,9 @@ _is_lto_kernel() {
     return $?
 }
 
-if _is_lto_kernel && [ "$_use_lto_suffix" = "y"  ]; then
+if _is_lto_kernel && [ "$_use_lto_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-rc-lto"
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "y" ]; then
+elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-rc-gcc"
 else
     _pkgsuffix="cachyos-rc"
@@ -241,13 +241,13 @@ if [[ "$_cpusched" = "rt" || "$_cpusched" = "rt-bore" ]]; then
 fi
 
 # ZFS support
-if [ -n "$_build_zfs" ]; then
+if [ "$_build_zfs" = "yes" ]; then
     makedepends+=(git)
     source+=("git+https://github.com/cachyos/zfs.git#commit=e65f69e41f4a276d7d0d1800a2878308a0ba84a6")
 fi
 
 # NVIDIA pre-build module support
-if [ -n "$_build_nvidia" ]; then
+if [ "$_build_nvidia" = "yes" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch"
              "${_patchsource}/misc/nvidia/0008-Kbuild-Use-absolute-paths-for-symbolic-links.patch"
@@ -255,7 +255,7 @@ if [ -n "$_build_nvidia" ]; then
              "${_patchsource}/misc/nvidia/0010-FROM-AOSC-TTM-fbdev-emulation-for-Linux-6.13.patch")
 fi
 
-if [ -n "$_build_nvidia_open" ]; then
+if [ "$_build_nvidia_open" = "yes" ]; then
     source+=("nvidia-open-${_nv_ver}.tar.gz::https://github.com/NVIDIA/open-gpu-kernel-modules/archive/refs/tags/${_nv_ver}.tar.gz"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch"
              "${_patchsource}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch"
@@ -270,7 +270,7 @@ if [ -n "$_build_nvidia_open" ]; then
 fi
 
 # Use generated AutoFDO Profile
-if [ -n "$_autofdo" ] && [ -n "$_autofdo_profile_name" ]; then
+if [ "$_autofdo" = "yes" ] && [ -n "$_autofdo_profile_name" ]; then
     if [ -e "$_autofdo_profile_name" ]; then
         source+=("$_autofdo_profile_name")
     else
@@ -279,7 +279,7 @@ if [ -n "$_autofdo" ] && [ -n "$_autofdo_profile_name" ]; then
 fi
 
 # Use generated Propeller Profile
-if [ -n "$_propeller" ] && [ -n "$_propeller_profiles" ]; then
+if [ "$_propeller" = "yes" ] && [ "$_propeller_profiles" = "yes" ]; then
     source+=(propeller_cc_profile.txt
              propeller_ld_profile.txt)
 fi
@@ -338,19 +338,17 @@ prepare() {
     fi
 
     ### Use autooptimization
-    if [ -n "$_use_auto_optimization" ]; then
+    if [ "$_use_auto_optimization" = "yes" ]; then
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
     ### Selecting CachyOS config
-    if [ -n "$_cachy_config" ]; then
+    if [ "$_cachy_config" = "yes" ]; then
         echo "Enabling CachyOS config..."
         scripts/config -e CACHY
     fi
 
     ### Selecting the CPU scheduler
-    [ -z "$_cpusched" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_cpusched" in
         cachyos|bore|hardened) scripts/config -e SCHED_BORE;;
         bmq) scripts/config -e SCHED_ALT -e SCHED_BMQ;;
@@ -365,14 +363,12 @@ prepare() {
     ### Enable KCFI
     ### Broken with NVIDIA Driver
     ### Needs to be reported
-    if [ -n "$_use_kcfi" ]; then
+    if [ "$_use_kcfi" = "yes" ]; then
         echo "Enabling kCFI"
         scripts/config -e ARCH_SUPPORTS_CFI_CLANG -e CFI_CLANG -e CFI_AUTO_DEFAULT
     fi
 
     ### Select LLVM level
-    [ -z "$_use_llvm_lto" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_use_llvm_lto" in
         thin) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -d LTO_CLANG_FULL -e LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
         full) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -e LTO_CLANG_FULL -d LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
@@ -383,8 +379,6 @@ prepare() {
     echo "Selecting '$_use_llvm_lto' LLVM level..."
 
     ### Select tick rate
-    [ -z "$_HZ_ticks" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_HZ_ticks" in
         100|250|500|600|625|750|1000)
             scripts/config -d HZ_300 -e "HZ_${_HZ_ticks}" --set-val HZ "${_HZ_ticks}";;
@@ -397,7 +391,7 @@ prepare() {
     echo "Setting tick rate to ${_HZ_ticks}Hz..."
 
     ### Disable NUMA
-    if [ -n "$_NUMAdisable" ]; then
+    if [ "$_NUMAdisable" = "yes" ]; then
         echo "Disabling NUMA from kernel config..."
         scripts/config -d NUMA \
             -d AMD_NUMA \
@@ -415,15 +409,13 @@ prepare() {
     fi
 
     ### Select performance governor
-    if [ -n "$_per_gov" ]; then
+    if [ "$_per_gov" = "yes" ]; then
         echo "Setting performance governor..."
         scripts/config -d CPU_FREQ_DEFAULT_GOV_SCHEDUTIL \
             -e CPU_FREQ_DEFAULT_GOV_PERFORMANCE
     fi
 
     ### Select tick type
-    [ -z "$_tickrate" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_tickrate" in
         perodic) scripts/config -d NO_HZ_IDLE -d NO_HZ_FULL -d NO_HZ -d NO_HZ_COMMON -e HZ_PERIODIC;;
         idle) scripts/config -d HZ_PERIODIC -d NO_HZ_FULL -e NO_HZ_IDLE  -e NO_HZ -e NO_HZ_COMMON;;
@@ -437,8 +429,6 @@ prepare() {
 
     # We should not set up the PREEMPT for RT kernels
     if [[ "$_cpusched" != "rt" || "$_cpusched" != "rt-bore" ]]; then
-        [ -z "$_preempt" ] && _die "The value is empty. Choose the correct one again."
-
         case "$_preempt" in
             full) scripts/config -e PREEMPT_DYNAMIC -e PREEMPT -d PREEMPT_VOLUNTARY -d PREEMPT_LAZY -d PREEMPT_NONE;;
             lazy) scripts/config -e PREEMPT_DYNAMIC -d PREEMPT -d PREEMPT_VOLUNTARY -e PREEMPT_LAZY -d PREEMPT_NONE;;
@@ -451,7 +441,7 @@ prepare() {
     fi
 
     ### Enable O3
-    if [ -n "$_cc_harder" ] && [ -z "$_cc_size" ]; then
+    if [ "$_cc_harder" = "yes" ]; then
         echo "Enabling KBUILD_CFLAGS -O3..."
         scripts/config -d CC_OPTIMIZE_FOR_PERFORMANCE \
             -e CC_OPTIMIZE_FOR_PERFORMANCE_O3
@@ -474,7 +464,7 @@ prepare() {
     fi
 
     ### Enable bbr3
-    if [ -n "$_tcp_bbr3" ]; then
+    if [ "$_tcp_bbr3" = "yes" ]; then
         echo "Disabling TCP_CONG_CUBIC..."
         scripts/config -m TCP_CONG_CUBIC \
             -d DEFAULT_CUBIC \
@@ -488,8 +478,6 @@ prepare() {
     fi
 
     ### Select THP
-    [ -z "$_hugepage" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_hugepage" in
         always) scripts/config -d TRANSPARENT_HUGEPAGE_MADVISE -e TRANSPARENT_HUGEPAGE_ALWAYS;;
         madvise) scripts/config -d TRANSPARENT_HUGEPAGE_ALWAYS -e TRANSPARENT_HUGEPAGE_MADVISE;;
@@ -500,20 +488,21 @@ prepare() {
 
     # Enable Clang AutoFDO
     # Add additonal check if Thin or Full LTO is enabled otherwise die
-    if [ -n "$_autofdo" ]; then
+    if [ "$_autofdo" = "yes" ]; then
         scripts/config -e AUTOFDO_CLANG
     fi
 
-    if [ -n "$_autofdo" ] && [ -n "$_autofdo_profile_name" ]; then
+    if [ "$_autofdo" = "yes" ] && [ -n "$_autofdo_profile_name" ]; then
         echo "AutoFDO profile has been found..."
         BUILD_FLAGS+=(CLANG_AUTOFDO_PROFILE="${srcdir}/${_autofdo_profile_name}")
     fi
 
     # Propeller Optimization
-    if [ -n "$_propeller" ]; then
+    if [ "$_propeller" = "yes" ]; then
         scripts/config -e PROPELLER_CLANG
     fi
-    if [ -n "$_propeller" ] && [ -n "$_propeller_profiles" ]; then
+
+    if [ "$_propeller" = "yes" ] && [ "$_propeller_profiles" = "yes" ]; then
         echo "Propeller profile has been found..."
         BUILD_FLAGS+=(CLANG_PROPELLER_PROFILE_PREFIX="${srcdir}/propeller")
     fi
@@ -523,7 +512,7 @@ prepare() {
 
     ### Optionally use running kernel's config
     # code originally by nous; http://aur.archlinux.org/packages.php?ID=40191
-    if [ -n "$_use_current" ]; then
+    if [ "$_use_current" = "yes" ]; then
         if [[ -s /proc/config.gz ]]; then
             echo "Extracting config from /proc/config.gz..."
             # modprobe configs
@@ -536,10 +525,9 @@ prepare() {
         fi
     fi
 
-
     ### Optionally load needed modules for the make localmodconfig
     # See https://aur.archlinux.org/packages/modprobed-db
-    if [ -n "$_localmodcfg" ]; then
+    if [ "$_localmodcfg" = "yes" ]; then
         if [ -e "$_localmodcfg_path" ]; then
             echo "Running Steven Rostedt's make localmodconfig now"
             make "${BUILD_FLAGS[@]}" LSMOD="${_localmodcfg_path}" localmodconfig
@@ -559,23 +547,23 @@ prepare() {
     echo "Prepared $pkgbase version $(<version)"
 
     ### Running make nconfig
-    [[ -z "$_makenconfig" ]] ||  make "${BUILD_FLAGS[@]}" nconfig
+    [ "$_makenconfig" = "yes" ] && make "${BUILD_FLAGS[@]}" nconfig
 
     ### Running make menuconfig
-    [[ -z "$_makemenuconfig" ]] ||  make "${BUILD_FLAGS[@]}" menuconfig
+    [ "$_makemenuconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" menuconfig
 
     ### Running make xconfig
-    [[ -z "$_makexconfig" ]] ||  make "${BUILD_FLAGS[@]}" xconfig
+    [ "$_makexconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" xconfig
 
     ### Running make gconfig
-    [[ -z "$_makegconfig" ]] ||  make "${BUILD_FLAGS[@]}" gconfig
+    [ "$_makegconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" gconfig
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
     local basedir="$(dirname "$(readlink "${srcdir}/config")")"
     cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
 
@@ -592,7 +580,7 @@ prepare() {
         patch -Np2 -i "${srcdir}/0010-FROM-AOSC-TTM-fbdev-emulation-for-Linux-6.13.patch" -d "${srcdir}/${_nv_pkg}/kernel"
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         # Use fbdev and modeset as default
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_open_pkg}/kernel-open"
 
@@ -637,20 +625,20 @@ build() {
        SYSSRC="${srcdir}/${_srcname}"
        SYSOUT="${srcdir}/${_srcname}"
     )
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         MODULE_FLAGS+=(NV_EXCLUDE_BUILD_MODULES='__EXCLUDE_MODULES')
         cd "${srcdir}/${_nv_pkg}/kernel"
         make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
 
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         cd "${srcdir}/${_nv_open_pkg}"
         MODULE_FLAGS+=(IGNORE_CC_MISMATCH=yes)
         CFLAGS= CXXFLAGS= LDFLAGS= make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
     fi
 
-    if [ -n "$_build_zfs" ]; then
+    if [ "$_build_zfs" = "yes" ]; then
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
@@ -846,11 +834,11 @@ _package-nvidia-open(){
 }
 
 pkgname=("$pkgbase")
-[ -n "$_build_debug" ] && pkgname+=("$pkgbase-dbg")
+[ "$_build_debug" = "yes" ] && pkgname+=("$pkgbase-dbg")
 pkgname+=("$pkgbase-headers")
-[ -n "$_build_zfs" ] && pkgname+=("$pkgbase-zfs")
-[ -n "$_build_nvidia" ] && pkgname+=("$pkgbase-nvidia")
-[ -n "$_build_nvidia_open" ] && pkgname+=("$pkgbase-nvidia-open")
+[ "$_build_zfs" = "yes" ] && pkgname+=("$pkgbase-zfs")
+[ "$_build_nvidia" = "yes" ] && pkgname+=("$pkgbase-nvidia")
+[ "$_build_nvidia_open" = "yes" ] && pkgname+=("$pkgbase-nvidia-open")
 for _p in "${pkgname[@]}"; do
     eval "package_$_p() {
     $(declare -f "_package${_p#$pkgbase}")

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-_cachy_config=${_cachy_config-y}
+: "${_cachy_config:=y}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -20,25 +20,25 @@ _cachy_config=${_cachy_config-y}
 # 'eevdf' - select 'EEVDF Scheduler'
 # 'rt' - select EEVDF, but includes a series of realtime patches
 # 'rt-bore' - select Burst-Oriented Response Enhancer, but includes a series of realtime patches
-_cpusched=${_cpusched-cachyos}
+: "${_cpusched:=cachyos}"
 
 ### Tweak kernel options prior to a build via nconfig
-_makenconfig=${_makenconfig-}
+: "${_makenconfig:=}"
 
 ### Tweak kernel options prior to a build via menuconfig
-_makemenuconfig=${_makemenuconfig-}
+: "${_makemenuconfig:=}"
 
 ### Tweak kernel options prior to a build via xconfig
-_makexconfig=${_makexconfig-}
+: "${_makexconfig:=}"
 
 ### Tweak kernel options prior to a build via gconfig
-_makegconfig=${_makegconfig-}
+: "${_makegconfig:=}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-_NUMAdisable=${_NUMAdisable-}
+: "${_NUMAdisable:=}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,36 +48,36 @@ _NUMAdisable=${_NUMAdisable-}
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-_localmodcfg=${_localmodcfg-}
+: "${_localmodcfg:=}"
 
 # Path to the list of used modules
-_localmodcfg_path=${_localmodcfg_path-"$HOME/.config/modprobed.db"}
+: "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
 
 # Use the current kernel's .config file
 # Enabling this option will use the .config of the RUNNING kernel rather than
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-_use_current=${_use_current-}
+: "${_use_current:=}"
 
 ### Enable KBUILD_CFLAGS -O3
-_cc_harder=${_cc_harder-y}
+: "${_cc_harder:=y}"
 
 ### Set performance governor as default
-_per_gov=${_per_gov-}
+: "${_per_gov:=}"
 
 ### Enable TCP_CONG_BBR3
-_tcp_bbr3=${_tcp_bbr3-}
+: "${_tcp_bbr3:=}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
-_HZ_ticks=${_HZ_ticks-1000}
+: "${_HZ_ticks:=1000}"
 
 ## Choose between perodic, idle or full
 ### Full tickless can give higher performances in various cases but, depending on hardware, lower consistency.
-_tickrate=${_tickrate-full}
+: "${_tickrate:=full}"
 
 ## Choose between full(low-latency), lazy, voluntary or none
-_preempt=${_preempt-full}
+: "${_preempt:=full}"
 
 ### Transparent Hugepages
 # ATTENTION - one of two predefined values should be selected!
@@ -85,7 +85,7 @@ _preempt=${_preempt-full}
 # 'madvise' - madvise, prevent applications from allocating more memory resources than necessary
 # More infos here:
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/performance_tuning_guide/sect-red_hat_enterprise_linux-performance_tuning_guide-configuring_transparent_huge_pages
-_hugepage=${_hugepage-always}
+: "${_hugepage:=always}"
 
 # CPU compiler optimizations - Defaults to prompt at kernel config if left empty
 # AMD CPUs : "k8" "k8sse3" "k10" "barcelona" "bobcat" "jaguar" "bulldozer" "piledriver" "steamroller" "excavator" "zen" "zen2" "zen3" "zen4"
@@ -95,51 +95,51 @@ _hugepage=${_hugepage-always}
 # - "native_intel" (use compiler autodetection and will prompt for P6_NOPS - Selecting your arch manually in the list above is recommended instead of this option)
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 #
-_processor_opt=${_processor_opt-}
+: "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-_use_auto_optimization=${_use_auto_optimization-y}
+: "${_use_auto_optimization:=y}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
 # "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
 # "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
 # "none: disable LTO
-_use_llvm_lto=${_use_llvm_lto-thin}
+: "${_use_llvm_lto:=thin}"
 
 # Use suffix -lto only when requested by the user
 # y - enable -lto suffix
 # n - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-_use_lto_suffix=${_use_lto_suffix-}
+: "${_use_lto_suffix:=}"
 
 # Use suffix -gcc when requested by the user
 # Enabled by default to show the difference between LTO kernels and GCC kernels
-_use_gcc_suffix=${_use_gcc_suffix-y}
+: "${_use_gcc_suffix:=y}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-_use_kcfi=${_use_kcfi-}
+: "${_use_kcfi:=}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-_build_zfs=${_build_zfs-}
+: "${_build_zfs:=}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-_build_nvidia=${_build_nvidia-}
+: "${_build_nvidia:=}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-_build_nvidia_open=${_build_nvidia_open-}
+: "${_build_nvidia_open:=}"
 
 # Build a debug package with non-stripped vmlinux
-_build_debug=${_build_debug-}
+: "${_build_debug:=}"
 
 # Enable AUTOFDO_CLANG for the first compilation to create a kernel, which can be used for profiling
 # Workflow:
@@ -149,10 +149,10 @@ _build_debug=${_build_debug-}
 # 3. Profile the kernel and convert the profile, see Generating the Profile for AutoFDO
 # 4. Put the profile into the sourcedir
 # 5. Run kernel build again with the _autofdo_profile_name path to profile specified
-_autofdo=${_autofdo-}
+: "${_autofdo:=}"
 
 # Name for the AutoFDO profile
-_autofdo_profile_name=${_autofdo_profile_name-}
+: "${_autofdo_profile_name:=}"
 
 # Propeller should be applied, after the kernel is optimized with AutoFDO
 # Workflow:

--- a/linux-cachyos-rt-bore/PKGBUILD
+++ b/linux-cachyos-rt-bore/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-_cachy_config=${_cachy_config-y}
+: "${_cachy_config:=y}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -20,25 +20,25 @@ _cachy_config=${_cachy_config-y}
 # 'eevdf' - select 'EEVDF Scheduler'
 # 'rt' - select EEVDF, but includes a series of realtime patches
 # 'rt-bore' - select Burst-Oriented Response Enhancer, but includes a series of realtime patches
-_cpusched=${_cpusched-rt-bore}
+: "${_cpusched:=rt-bore}"
 
 ### Tweak kernel options prior to a build via nconfig
-_makenconfig=${_makenconfig-}
+: "${_makenconfig:=}"
 
 ### Tweak kernel options prior to a build via menuconfig
-_makemenuconfig=${_makemenuconfig-}
+: "${_makemenuconfig:=}"
 
 ### Tweak kernel options prior to a build via xconfig
-_makexconfig=${_makexconfig-}
+: "${_makexconfig:=}"
 
 ### Tweak kernel options prior to a build via gconfig
-_makegconfig=${_makegconfig-}
+: "${_makegconfig:=}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-_NUMAdisable=${_NUMAdisable-}
+: "${_NUMAdisable:=}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,36 +48,36 @@ _NUMAdisable=${_NUMAdisable-}
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-_localmodcfg=${_localmodcfg-}
+: "${_localmodcfg:=}"
 
 # Path to the list of used modules
-_localmodcfg_path=${_localmodcfg_path-"$HOME/.config/modprobed.db"}
+: "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
 
 # Use the current kernel's .config file
 # Enabling this option will use the .config of the RUNNING kernel rather than
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-_use_current=${_use_current-}
+: "${_use_current:=}"
 
 ### Enable KBUILD_CFLAGS -O3
-_cc_harder=${_cc_harder-y}
+: "${_cc_harder:=y}"
 
 ### Set performance governor as default
-_per_gov=${_per_gov-}
+: "${_per_gov:=}"
 
 ### Enable TCP_CONG_BBR3
-_tcp_bbr3=${_tcp_bbr3-}
+: "${_tcp_bbr3:=}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
-_HZ_ticks=${_HZ_ticks-1000}
+: "${_HZ_ticks:=1000}"
 
 ## Choose between perodic, idle or full
 ### Full tickless can give higher performances in various cases but, depending on hardware, lower consistency.
-_tickrate=${_tickrate-full}
+: "${_tickrate:=full}"
 
 ## Choose between full(low-latency), voluntary or server
-_preempt=${_preempt-full}
+: "${_preempt:=full}"
 
 ### Transparent Hugepages
 # ATTENTION - one of two predefined values should be selected!
@@ -85,7 +85,7 @@ _preempt=${_preempt-full}
 # 'madvise' - madvise, prevent applications from allocating more memory resources than necessary
 # More infos here:
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/performance_tuning_guide/sect-red_hat_enterprise_linux-performance_tuning_guide-configuring_transparent_huge_pages
-_hugepage=${_hugepage-always}
+: "${_hugepage:=always}"
 
 # CPU compiler optimizations - Defaults to prompt at kernel config if left empty
 # AMD CPUs : "k8" "k8sse3" "k10" "barcelona" "bobcat" "jaguar" "bulldozer" "piledriver" "steamroller" "excavator" "zen" "zen2" "zen3" "zen4"
@@ -95,52 +95,52 @@ _hugepage=${_hugepage-always}
 # - "native_intel" (use compiler autodetection and will prompt for P6_NOPS - Selecting your arch manually in the list above is recommended instead of this option)
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 #
-_processor_opt=${_processor_opt-}
+: "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-_use_auto_optimization=${_use_auto_optimization-y}
+: "${_use_auto_optimization:=y}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
 # "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
 # "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
 # "none: disable LTO
-_use_llvm_lto=${_use_llvm_lto-none}
+: "${_use_llvm_lto:=none}"
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
 # y - enable -lto suffix
 # n - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-_use_lto_suffix=${_use_lto_suffix-y}
+: "${_use_lto_suffix:=y}"
 
 # Use suffix -gcc when requested by the user
 # This was added to facilitate https://github.com/CachyOS/linux-cachyos/issues/286
-_use_gcc_suffix=${_use_gcc_suffix-}
+: "${_use_gcc_suffix:=}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-_use_kcfi=${_use_kcfi-}
+: "${_use_kcfi:=}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-_build_zfs=${_build_zfs-}
+: "${_build_zfs:=}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-_build_nvidia=${_build_nvidia-}
+: "${_build_nvidia:=}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-_build_nvidia_open=${_build_nvidia_open-}
+: "${_build_nvidia_open:=}"
 
 # Build a debug package with non-stripped vmlinux
-_build_debug=${_build_debug-}
+: "${_build_debug:=}"
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {

--- a/linux-cachyos-rt-bore/PKGBUILD
+++ b/linux-cachyos-rt-bore/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-: "${_cachy_config:=y}"
+: "${_cachy_config:=yes}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -23,22 +23,22 @@
 : "${_cpusched:=rt-bore}"
 
 ### Tweak kernel options prior to a build via nconfig
-: "${_makenconfig:=}"
+: "${_makenconfig:=no}"
 
 ### Tweak kernel options prior to a build via menuconfig
-: "${_makemenuconfig:=}"
+: "${_makemenuconfig:=no}"
 
 ### Tweak kernel options prior to a build via xconfig
-: "${_makexconfig:=}"
+: "${_makexconfig:=no}"
 
 ### Tweak kernel options prior to a build via gconfig
-: "${_makegconfig:=}"
+: "${_makegconfig:=no}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-: "${_NUMAdisable:=}"
+: "${_NUMAdisable:=no}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,7 +48,7 @@
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-: "${_localmodcfg:=}"
+: "${_localmodcfg:=no}"
 
 # Path to the list of used modules
 : "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
@@ -58,16 +58,16 @@
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-: "${_use_current:=}"
+: "${_use_current:=no}"
 
 ### Enable KBUILD_CFLAGS -O3
-: "${_cc_harder:=y}"
+: "${_cc_harder:=yes}"
 
 ### Set performance governor as default
-: "${_per_gov:=}"
+: "${_per_gov:=no}"
 
 ### Enable TCP_CONG_BBR3
-: "${_tcp_bbr3:=}"
+: "${_tcp_bbr3:=no}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
 : "${_HZ_ticks:=1000}"
@@ -98,7 +98,7 @@
 : "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-: "${_use_auto_optimization:=y}"
+: "${_use_auto_optimization:=yes}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
@@ -109,38 +109,38 @@
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
-# y - enable -lto suffix
-# n - disable -lto suffix
+# yes - enable -lto suffix
+# no - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-: "${_use_lto_suffix:=y}"
+: "${_use_lto_suffix:=yes}"
 
 # Use suffix -gcc when requested by the user
 # This was added to facilitate https://github.com/CachyOS/linux-cachyos/issues/286
-: "${_use_gcc_suffix:=}"
+: "${_use_gcc_suffix:=no}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-: "${_use_kcfi:=}"
+: "${_use_kcfi:=no}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-: "${_build_zfs:=}"
+: "${_build_zfs:=no}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-: "${_build_nvidia:=}"
+: "${_build_nvidia:=no}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-: "${_build_nvidia_open:=}"
+: "${_build_nvidia_open:=no}"
 
 # Build a debug package with non-stripped vmlinux
-: "${_build_debug:=}"
+: "${_build_debug:=no}"
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
@@ -148,9 +148,9 @@ _is_lto_kernel() {
     return $?
 }
 
-if _is_lto_kernel && [ "$_use_lto_suffix" = "y"  ]; then
+if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix="cachyos-${_cpusched}-lto"
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "y" ]; then
+elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-${_cpusched}-gcc"
 else
     _pkgsuffix="cachyos-${_cpusched}"
@@ -216,18 +216,18 @@ if [[ "$_cpusched" = "rt" || "$_cpusched" = "rt-bore" ]]; then
 fi
 
 # ZFS support
-if [ -n "$_build_zfs" ]; then
+if [ "$_build_zfs" = "yes" ]; then
     makedepends+=(git)
     source+=("git+https://github.com/cachyos/zfs.git#commit=e65f69e41f4a276d7d0d1800a2878308a0ba84a6")
 fi
 
 # NVIDIA pre-build module support
-if [ -n "$_build_nvidia" ]; then
+if [ "$_build_nvidia" = "yes" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch")
 fi
 
-if [ -n "$_build_nvidia_open" ]; then
+if [ "$_build_nvidia_open" = "yes" ]; then
     source+=("nvidia-open-${_nv_ver}.tar.gz::https://github.com/NVIDIA/open-gpu-kernel-modules/archive/refs/tags/${_nv_ver}.tar.gz"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch"
              "${_patchsource}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch"
@@ -294,19 +294,17 @@ prepare() {
     fi
 
     ### Use autooptimization
-    if [ -n "$_use_auto_optimization" ]; then
+    if [ "$_use_auto_optimization" = "yes" ]; then
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
     ### Selecting CachyOS config
-    if [ -n "$_cachy_config" ]; then
+    if [ "$_cachy_config" = "yes" ]; then
         echo "Enabling CachyOS config..."
         scripts/config -e CACHY
     fi
 
     ### Selecting the CPU scheduler
-    [ -z "$_cpusched" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_cpusched" in
         cachyos|bore|hardened) scripts/config -e SCHED_BORE;;
         bmq) scripts/config -e SCHED_ALT -e SCHED_BMQ;;
@@ -319,14 +317,12 @@ prepare() {
     echo "Selecting ${_cpusched^^} CPU scheduler..."
 
     ### Enable KCFI
-    if [ -n "$_use_kcfi" ]; then
+    if [ "$_use_kcfi" = "yes" ]; then
         echo "Enabling kCFI"
         scripts/config -e ARCH_SUPPORTS_CFI_CLANG -e CFI_CLANG -e CFI_AUTO_DEFAULT
     fi
 
     ### Select LLVM level
-    [ -z "$_use_llvm_lto" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_use_llvm_lto" in
         thin) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -d LTO_CLANG_FULL -e LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
         full) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -e LTO_CLANG_FULL -d LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
@@ -337,8 +333,6 @@ prepare() {
     echo "Selecting '$_use_llvm_lto' LLVM level..."
 
     ### Select tick rate
-    [ -z "$_HZ_ticks" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_HZ_ticks" in
         100|250|500|600|625|750|1000)
             scripts/config -d HZ_300 -e "HZ_${_HZ_ticks}" --set-val HZ "${_HZ_ticks}";;
@@ -351,7 +345,7 @@ prepare() {
     echo "Setting tick rate to ${_HZ_ticks}Hz..."
 
     ### Disable NUMA
-    if [ -n "$_NUMAdisable" ]; then
+    if [ "$_NUMAdisable" = "yes" ]; then
         echo "Disabling NUMA from kernel config..."
         scripts/config -d NUMA \
             -d AMD_NUMA \
@@ -369,15 +363,13 @@ prepare() {
     fi
 
     ### Select performance governor
-    if [ -n "$_per_gov" ]; then
+    if [ "$_per_gov" = "yes" ]; then
         echo "Setting performance governor..."
         scripts/config -d CPU_FREQ_DEFAULT_GOV_SCHEDUTIL \
             -e CPU_FREQ_DEFAULT_GOV_PERFORMANCE
     fi
 
     ### Select tick type
-    [ -z "$_tickrate" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_tickrate" in
         perodic) scripts/config -d NO_HZ_IDLE -d NO_HZ_FULL -d NO_HZ -d NO_HZ_COMMON -e HZ_PERIODIC;;
         idle) scripts/config -d HZ_PERIODIC -d NO_HZ_FULL -e NO_HZ_IDLE  -e NO_HZ -e NO_HZ_COMMON;;
@@ -391,8 +383,6 @@ prepare() {
 
     # We should not set up the PREEMPT for RT kernels
     if [[ "$_cpusched" != "rt" || "$_cpusched" != "rt-bore" ]]; then
-        [ -z "$_preempt" ] && _die "The value is empty. Choose the correct one again."
-
         case "$_preempt" in
             full) scripts/config -e PREEMPT_BUILD -d PREEMPT_NONE -d PREEMPT_VOLUNTARY -e PREEMPT -e PREEMPT_COUNT -e PREEMPTION -e PREEMPT_DYNAMIC;;
             voluntary) scripts/config -e PREEMPT_BUILD -d PREEMPT_NONE -e PREEMPT_VOLUNTARY -d PREEMPT -e PREEMPT_COUNT -e PREEMPTION -d PREEMPT_DYNAMIC;;
@@ -404,7 +394,7 @@ prepare() {
     fi
 
     ### Enable O3
-    if [ -n "$_cc_harder" ] && [ -z "$_cc_size" ]; then
+    if [ "$_cc_harder" = "yes" ]; then
         echo "Enabling KBUILD_CFLAGS -O3..."
         scripts/config -d CC_OPTIMIZE_FOR_PERFORMANCE \
             -e CC_OPTIMIZE_FOR_PERFORMANCE_O3
@@ -427,7 +417,7 @@ prepare() {
     fi
 
     ### Enable bbr3
-    if [ -n "$_tcp_bbr3" ]; then
+    if [ "$_tcp_bbr3" = "yes" ]; then
         echo "Disabling TCP_CONG_CUBIC..."
         scripts/config -m TCP_CONG_CUBIC \
             -d DEFAULT_CUBIC \
@@ -441,8 +431,6 @@ prepare() {
     fi
 
     ### Select THP
-    [ -z "$_hugepage" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_hugepage" in
         always) scripts/config -d TRANSPARENT_HUGEPAGE_MADVISE -e TRANSPARENT_HUGEPAGE_ALWAYS;;
         madvise) scripts/config -d TRANSPARENT_HUGEPAGE_ALWAYS -e TRANSPARENT_HUGEPAGE_MADVISE;;
@@ -456,7 +444,7 @@ prepare() {
 
     ### Optionally use running kernel's config
     # code originally by nous; http://aur.archlinux.org/packages.php?ID=40191
-    if [ -n "$_use_current" ]; then
+    if [ "$_use_current" = "yes" ]; then
         if [[ -s /proc/config.gz ]]; then
             echo "Extracting config from /proc/config.gz..."
             # modprobe configs
@@ -469,10 +457,9 @@ prepare() {
         fi
     fi
 
-
     ### Optionally load needed modules for the make localmodconfig
     # See https://aur.archlinux.org/packages/modprobed-db
-    if [ -n "$_localmodcfg" ]; then
+    if [ "$_localmodcfg" = "yes" ]; then
         if [ -e "$_localmodcfg_path" ]; then
             echo "Running Steven Rostedt's make localmodconfig now"
             make "${BUILD_FLAGS[@]}" LSMOD="${_localmodcfg_path}" localmodconfig
@@ -492,23 +479,23 @@ prepare() {
     echo "Prepared $pkgbase version $(<version)"
 
     ### Running make nconfig
-    [[ -z "$_makenconfig" ]] ||  make "${BUILD_FLAGS[@]}" nconfig
+    [ "$_makenconfig" = "yes" ] && make "${BUILD_FLAGS[@]}" nconfig
 
     ### Running make menuconfig
-    [[ -z "$_makemenuconfig" ]] ||  make "${BUILD_FLAGS[@]}" menuconfig
+    [ "$_makemenuconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" menuconfig
 
     ### Running make xconfig
-    [[ -z "$_makexconfig" ]] ||  make "${BUILD_FLAGS[@]}" xconfig
+    [ "$_makexconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" xconfig
 
     ### Running make gconfig
-    [[ -z "$_makegconfig" ]] ||  make "${BUILD_FLAGS[@]}" gconfig
+    [ "$_makegconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" gconfig
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
     local basedir="$(dirname "$(readlink "${srcdir}/config")")"
     cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
 
@@ -516,7 +503,7 @@ prepare() {
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_pkg}/kernel"
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_open_pkg}/kernel-open"
         # Fix for Zen5 error print in dmesg
         patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch" -d "${srcdir}/${_nv_open_pkg}"
@@ -540,20 +527,20 @@ build() {
        SYSSRC="${srcdir}/${_srcname}"
        SYSOUT="${srcdir}/${_srcname}"
     )
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         MODULE_FLAGS+=(NV_EXCLUDE_BUILD_MODULES='__EXCLUDE_MODULES')
         cd "${srcdir}/${_nv_pkg}/kernel"
         make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
 
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         cd "${srcdir}/${_nv_open_pkg}"
         MODULE_FLAGS+=(IGNORE_CC_MISMATCH=yes)
         CFLAGS= CXXFLAGS= LDFLAGS= make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
     fi
 
-    if [ -n "$_build_zfs" ]; then
+    if [ "$_build_zfs" = "yes" ]; then
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
@@ -745,11 +732,11 @@ _package-nvidia-open(){
 }
 
 pkgname=("$pkgbase")
-[ -n "$_build_debug" ] && pkgname+=("$pkgbase-dbg")
+[ "$_build_debug" = "yes" ] && pkgname+=("$pkgbase-dbg")
 pkgname+=("$pkgbase-headers")
-[ -n "$_build_zfs" ] && pkgname+=("$pkgbase-zfs")
-[ -n "$_build_nvidia" ] && pkgname+=("$pkgbase-nvidia")
-[ -n "$_build_nvidia_open" ] && pkgname+=("$pkgbase-nvidia-open")
+[ "$_build_zfs" = "yes" ] && pkgname+=("$pkgbase-zfs")
+[ "$_build_nvidia" = "yes" ] && pkgname+=("$pkgbase-nvidia")
+[ "$_build_nvidia_open" = "yes" ] && pkgname+=("$pkgbase-nvidia-open")
 for _p in "${pkgname[@]}"; do
     eval "package_$_p() {
     $(declare -f "_package${_p#$pkgbase}")

--- a/linux-cachyos-server/PKGBUILD
+++ b/linux-cachyos-server/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-_cachy_config=${_cachy_config-}
+: "${_cachy_config:=}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -20,25 +20,25 @@ _cachy_config=${_cachy_config-}
 # 'eevdf' - select 'EEVDF Scheduler'
 # 'rt' - select EEVDF, but includes a series of realtime patches
 # 'rt-bore' - select Burst-Oriented Response Enhancer, but includes a series of realtime patches
-_cpusched=${_cpusched-eevdf}
+: "${_cpusched:=eevdf}"
 
 ### Tweak kernel options prior to a build via nconfig
-_makenconfig=${_makenconfig-}
+: "${_makenconfig:=}"
 
 ### Tweak kernel options prior to a build via menuconfig
-_makemenuconfig=${_makemenuconfig-}
+: "${_makemenuconfig:=}"
 
 ### Tweak kernel options prior to a build via xconfig
-_makexconfig=${_makexconfig-}
+: "${_makexconfig:=}"
 
 ### Tweak kernel options prior to a build via gconfig
-_makegconfig=${_makegconfig-}
+: "${_makegconfig:=}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-_NUMAdisable=${_NUMAdisable-}
+: "${_NUMAdisable:=}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,36 +48,36 @@ _NUMAdisable=${_NUMAdisable-}
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-_localmodcfg=${_localmodcfg-}
+: "${_localmodcfg:=}"
 
 # Path to the list of used modules
-_localmodcfg_path=${_localmodcfg_path-"$HOME/.config/modprobed.db"}
+: "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
 
 # Use the current kernel's .config file
 # Enabling this option will use the .config of the RUNNING kernel rather than
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-_use_current=${_use_current-}
+: "${_use_current:=}"
 
 ### Enable KBUILD_CFLAGS -O3
-_cc_harder=${_cc_harder-y}
+: "${_cc_harder:=y}"
 
 ### Set performance governor as default
-_per_gov=${_per_gov-}
+: "${_per_gov:=}"
 
 ### Enable TCP_CONG_BBR3
-_tcp_bbr3=${_tcp_bbr3-}
+: "${_tcp_bbr3:=}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
-_HZ_ticks=${_HZ_ticks-300}
+: "${_HZ_ticks:=300}"
 
 ## Choose between perodic, idle or full
 ### Full tickless can give higher performances in various cases but, depending on hardware, lower consistency.
-_tickrate=${_tickrate-idle}
+: "${_tickrate:=idle}"
 
 ## Choose between full(low-latency), voluntary, server
-_preempt=${_preempt-server}
+: "${_preempt:=server}"
 
 ### Transparent Hugepages
 # ATTENTION - one of two predefined values should be selected!
@@ -85,7 +85,7 @@ _preempt=${_preempt-server}
 # 'madvise' - madvise, prevent applications from allocating more memory resources than necessary
 # More infos here:
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/performance_tuning_guide/sect-red_hat_enterprise_linux-performance_tuning_guide-configuring_transparent_huge_pages
-_hugepage=${_hugepage-always}
+: "${_hugepage:=always}"
 
 # CPU compiler optimizations - Defaults to prompt at kernel config if left empty
 # AMD CPUs : "k8" "k8sse3" "k10" "barcelona" "bobcat" "jaguar" "bulldozer" "piledriver" "steamroller" "excavator" "zen" "zen2" "zen3" "zen4"
@@ -95,52 +95,52 @@ _hugepage=${_hugepage-always}
 # - "native_intel" (use compiler autodetection and will prompt for P6_NOPS - Selecting your arch manually in the list above is recommended instead of this option)
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 #
-_processor_opt=${_processor_opt-}
+: "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-_use_auto_optimization=${_use_auto_optimization-y}
+: "${_use_auto_optimization:=y}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
 # "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
 # "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
 # "none: disable LTO
-_use_llvm_lto=${_use_llvm_lto-none}
+: "${_use_llvm_lto:=none}"
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
 # y - enable -lto suffix
 # n - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-_use_lto_suffix=${_use_lto_suffix-y}
+: "${_use_lto_suffix:=y}"
 
 # Use suffix -gcc when requested by the user
 # This was added to facilitate https://github.com/CachyOS/linux-cachyos/issues/286
-_use_gcc_suffix=${_use_gcc_suffix-}
+: "${_use_gcc_suffix:=}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-_use_kcfi=${_use_kcfi-}
+: "${_use_kcfi:=}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-_build_zfs=${_build_zfs-}
+: "${_build_zfs:=}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-_build_nvidia=${_build_nvidia-}
+: "${_build_nvidia:=}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-_build_nvidia_open=${_build_nvidia_open-}
+: "${_build_nvidia_open:=}"
 
 # Build a debug package with non-stripped vmlinux
-_build_debug=${_build_debug-}
+: "${_build_debug:=}"
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {

--- a/linux-cachyos-server/PKGBUILD
+++ b/linux-cachyos-server/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-: "${_cachy_config:=}"
+: "${_cachy_config:=no}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -23,22 +23,22 @@
 : "${_cpusched:=eevdf}"
 
 ### Tweak kernel options prior to a build via nconfig
-: "${_makenconfig:=}"
+: "${_makenconfig:=no}"
 
 ### Tweak kernel options prior to a build via menuconfig
-: "${_makemenuconfig:=}"
+: "${_makemenuconfig:=no}"
 
 ### Tweak kernel options prior to a build via xconfig
-: "${_makexconfig:=}"
+: "${_makexconfig:=no}"
 
 ### Tweak kernel options prior to a build via gconfig
-: "${_makegconfig:=}"
+: "${_makegconfig:=no}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-: "${_NUMAdisable:=}"
+: "${_NUMAdisable:=no}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,7 +48,7 @@
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-: "${_localmodcfg:=}"
+: "${_localmodcfg:=no}"
 
 # Path to the list of used modules
 : "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
@@ -58,16 +58,16 @@
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-: "${_use_current:=}"
+: "${_use_current:=no}"
 
 ### Enable KBUILD_CFLAGS -O3
-: "${_cc_harder:=y}"
+: "${_cc_harder:=yes}"
 
 ### Set performance governor as default
-: "${_per_gov:=}"
+: "${_per_gov:=no}"
 
 ### Enable TCP_CONG_BBR3
-: "${_tcp_bbr3:=}"
+: "${_tcp_bbr3:=no}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
 : "${_HZ_ticks:=300}"
@@ -98,7 +98,7 @@
 : "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-: "${_use_auto_optimization:=y}"
+: "${_use_auto_optimization:=yes}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
@@ -109,38 +109,38 @@
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
-# y - enable -lto suffix
-# n - disable -lto suffix
+# yes - enable -lto suffix
+# no - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-: "${_use_lto_suffix:=y}"
+: "${_use_lto_suffix:=yes}"
 
 # Use suffix -gcc when requested by the user
 # This was added to facilitate https://github.com/CachyOS/linux-cachyos/issues/286
-: "${_use_gcc_suffix:=}"
+: "${_use_gcc_suffix:=no}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-: "${_use_kcfi:=}"
+: "${_use_kcfi:=no}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-: "${_build_zfs:=}"
+: "${_build_zfs:=no}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-: "${_build_nvidia:=}"
+: "${_build_nvidia:=no}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-: "${_build_nvidia_open:=}"
+: "${_build_nvidia_open:=yes}"
 
 # Build a debug package with non-stripped vmlinux
-: "${_build_debug:=}"
+: "${_build_debug:=yes}"
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
@@ -148,9 +148,9 @@ _is_lto_kernel() {
     return $?
 }
 
-if _is_lto_kernel && [ "$_use_lto_suffix" = "y"  ]; then
+if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix="cachyos-server-lto"
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "y" ]; then
+elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-server-gcc"
 else
     _pkgsuffix="cachyos-server"
@@ -216,18 +216,18 @@ if [[ "$_cpusched" = "rt" || "$_cpusched" = "rt-bore" ]]; then
 fi
 
 # ZFS support
-if [ -n "$_build_zfs" ]; then
+if [ "$_build_zfs" = "yes" ]; then
     makedepends+=(git)
     source+=("git+https://github.com/cachyos/zfs.git#commit=e65f69e41f4a276d7d0d1800a2878308a0ba84a6")
 fi
 
 # NVIDIA pre-build module support
-if [ -n "$_build_nvidia" ]; then
+if [ "$_build_nvidia" = "yes" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch")
 fi
 
-if [ -n "$_build_nvidia_open" ]; then
+if [ "$_build_nvidia_open" = "yes" ]; then
     source+=("nvidia-open-${_nv_ver}.tar.gz::https://github.com/NVIDIA/open-gpu-kernel-modules/archive/refs/tags/${_nv_ver}.tar.gz"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch"
              "${_patchsource}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch"
@@ -294,19 +294,17 @@ prepare() {
     fi
 
     ### Use autooptimization
-    if [ -n "$_use_auto_optimization" ]; then
+    if [ "$_use_auto_optimization" = "yes" ]; then
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
     ### Selecting CachyOS config
-    if [ -n "$_cachy_config" ]; then
+    if [ "$_cachy_config" = "yes" ]; then
         echo "Enabling CachyOS config..."
         scripts/config -e CACHY
     fi
 
     ### Selecting the CPU scheduler
-    [ -z "$_cpusched" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_cpusched" in
         cachyos|bore|hardened) scripts/config -e SCHED_BORE;;
         bmq) scripts/config -e SCHED_ALT -e SCHED_BMQ;;
@@ -319,14 +317,12 @@ prepare() {
     echo "Selecting ${_cpusched^^} CPU scheduler..."
 
     ### Enable KCFI
-    if [ -n "$_use_kcfi" ]; then
+    if [ "$_use_kcfi" = "yes" ]; then
         echo "Enabling kCFI"
         scripts/config -e ARCH_SUPPORTS_CFI_CLANG -e CFI_CLANG -e CFI_AUTO_DEFAULT
     fi
 
     ### Select LLVM level
-    [ -z "$_use_llvm_lto" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_use_llvm_lto" in
         thin) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -d LTO_CLANG_FULL -e LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
         full) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -e LTO_CLANG_FULL -d LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
@@ -337,8 +333,6 @@ prepare() {
     echo "Selecting '$_use_llvm_lto' LLVM level..."
 
     ### Select tick rate
-    [ -z "$_HZ_ticks" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_HZ_ticks" in
         100|250|500|600|625|750|1000)
             scripts/config -d HZ_300 -e "HZ_${_HZ_ticks}" --set-val HZ "${_HZ_ticks}";;
@@ -351,7 +345,7 @@ prepare() {
     echo "Setting tick rate to ${_HZ_ticks}Hz..."
 
     ### Disable NUMA
-    if [ -n "$_NUMAdisable" ]; then
+    if [ "$_NUMAdisable" = "yes" ]; then
         echo "Disabling NUMA from kernel config..."
         scripts/config -d NUMA \
             -d AMD_NUMA \
@@ -369,15 +363,13 @@ prepare() {
     fi
 
     ### Select performance governor
-    if [ -n "$_per_gov" ]; then
+    if [ "$_per_gov" = "yes" ]; then
         echo "Setting performance governor..."
         scripts/config -d CPU_FREQ_DEFAULT_GOV_SCHEDUTIL \
             -e CPU_FREQ_DEFAULT_GOV_PERFORMANCE
     fi
 
     ### Select tick type
-    [ -z "$_tickrate" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_tickrate" in
         perodic) scripts/config -d NO_HZ_IDLE -d NO_HZ_FULL -d NO_HZ -d NO_HZ_COMMON -e HZ_PERIODIC;;
         idle) scripts/config -d HZ_PERIODIC -d NO_HZ_FULL -e NO_HZ_IDLE  -e NO_HZ -e NO_HZ_COMMON;;
@@ -391,8 +383,6 @@ prepare() {
 
     # We should not set up the PREEMPT for RT kernels
     if [[ "$_cpusched" != "rt" || "$_cpusched" != "rt-bore" ]]; then
-        [ -z "$_preempt" ] && _die "The value is empty. Choose the correct one again."
-
         case "$_preempt" in
             full) scripts/config -e PREEMPT_DYNAMIC -e PREEMPT -d PREEMPT_VOLUNTARY -d PREEMPT_NONE;;
             voluntary) scripts/config -d PREEMPT_DYNAMIC -e PREEMPT_VOLUNTARY_BUILD -d PREEMPT -e PREEMPT_VOLUNTARY -d PREEMPT_NONE;;
@@ -404,7 +394,7 @@ prepare() {
     fi
 
     ### Enable O3
-    if [ -n "$_cc_harder" ] && [ -z "$_cc_size" ]; then
+    if [ "$_cc_harder" = "yes" ]; then
         echo "Enabling KBUILD_CFLAGS -O3..."
         scripts/config -d CC_OPTIMIZE_FOR_PERFORMANCE \
             -e CC_OPTIMIZE_FOR_PERFORMANCE_O3
@@ -427,7 +417,7 @@ prepare() {
     fi
 
     ### Enable bbr3
-    if [ -n "$_tcp_bbr3" ]; then
+    if [ "$_tcp_bbr3" = "yes" ]; then
         echo "Disabling TCP_CONG_CUBIC..."
         scripts/config -m TCP_CONG_CUBIC \
             -d DEFAULT_CUBIC \
@@ -437,8 +427,6 @@ prepare() {
     fi
 
     ### Select THP
-    [ -z "$_hugepage" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_hugepage" in
         always) scripts/config -d TRANSPARENT_HUGEPAGE_MADVISE -e TRANSPARENT_HUGEPAGE_ALWAYS;;
         madvise) scripts/config -d TRANSPARENT_HUGEPAGE_ALWAYS -e TRANSPARENT_HUGEPAGE_MADVISE;;
@@ -452,7 +440,7 @@ prepare() {
 
     ### Optionally use running kernel's config
     # code originally by nous; http://aur.archlinux.org/packages.php?ID=40191
-    if [ -n "$_use_current" ]; then
+    if [ "$_use_current" = "yes" ]; then
         if [[ -s /proc/config.gz ]]; then
             echo "Extracting config from /proc/config.gz..."
             # modprobe configs
@@ -465,10 +453,9 @@ prepare() {
         fi
     fi
 
-
     ### Optionally load needed modules for the make localmodconfig
     # See https://aur.archlinux.org/packages/modprobed-db
-    if [ -n "$_localmodcfg" ]; then
+    if [ "$_localmodcfg" = "yes" ]; then
         if [ -e "$_localmodcfg_path" ]; then
             echo "Running Steven Rostedt's make localmodconfig now"
             make "${BUILD_FLAGS[@]}" LSMOD="${_localmodcfg_path}" localmodconfig
@@ -488,23 +475,23 @@ prepare() {
     echo "Prepared $pkgbase version $(<version)"
 
     ### Running make nconfig
-    [[ -z "$_makenconfig" ]] ||  make "${BUILD_FLAGS[@]}" nconfig
+    [ "$_makenconfig" = "yes" ] && make "${BUILD_FLAGS[@]}" nconfig
 
     ### Running make menuconfig
-    [[ -z "$_makemenuconfig" ]] ||  make "${BUILD_FLAGS[@]}" menuconfig
+    [ "$_makemenuconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" menuconfig
 
     ### Running make xconfig
-    [[ -z "$_makexconfig" ]] ||  make "${BUILD_FLAGS[@]}" xconfig
+    [ "$_makexconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" xconfig
 
     ### Running make gconfig
-    [[ -z "$_makegconfig" ]] ||  make "${BUILD_FLAGS[@]}" gconfig
+    [ "$_makegconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" gconfig
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
     local basedir="$(dirname "$(readlink "${srcdir}/config")")"
     cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
 
@@ -512,7 +499,7 @@ prepare() {
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_pkg}/kernel"
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_open_pkg}/kernel-open"
         # Fix for Zen5 error print in dmesg
         patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch" -d "${srcdir}/${_nv_open_pkg}"
@@ -536,20 +523,20 @@ build() {
        SYSSRC="${srcdir}/${_srcname}"
        SYSOUT="${srcdir}/${_srcname}"
     )
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         MODULE_FLAGS+=(NV_EXCLUDE_BUILD_MODULES='__EXCLUDE_MODULES')
         cd "${srcdir}/${_nv_pkg}/kernel"
         make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
 
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         cd "${srcdir}/${_nv_open_pkg}"
         MODULE_FLAGS+=(IGNORE_CC_MISMATCH=yes)
         CFLAGS= CXXFLAGS= LDFLAGS= make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
     fi
 
-    if [ -n "$_build_zfs" ]; then
+    if [ "$_build_zfs" = "yes" ]; then
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
@@ -741,11 +728,11 @@ _package-nvidia-open(){
 }
 
 pkgname=("$pkgbase")
-[ -n "$_build_debug" ] && pkgname+=("$pkgbase-dbg")
+[ "$_build_debug" = "yes" ] && pkgname+=("$pkgbase-dbg")
 pkgname+=("$pkgbase-headers")
-[ -n "$_build_zfs" ] && pkgname+=("$pkgbase-zfs")
-[ -n "$_build_nvidia" ] && pkgname+=("$pkgbase-nvidia")
-[ -n "$_build_nvidia_open" ] && pkgname+=("$pkgbase-nvidia-open")
+[ "$_build_zfs" = "yes" ] && pkgname+=("$pkgbase-zfs")
+[ "$_build_nvidia" = "yes" ] && pkgname+=("$pkgbase-nvidia")
+[ "$_build_nvidia_open" = "yes" ] && pkgname+=("$pkgbase-nvidia-open")
 for _p in "${pkgname[@]}"; do
     eval "package_$_p() {
     $(declare -f "_package${_p#$pkgbase}")

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-_cachy_config=${_cachy_config-y}
+: "${_cachy_config:=y}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -20,25 +20,25 @@ _cachy_config=${_cachy_config-y}
 # 'eevdf' - select 'EEVDF Scheduler'
 # 'rt' - select EEVDF, but includes a series of realtime patches
 # 'rt-bore' - select Burst-Oriented Response Enhancer, but includes a series of realtime patches
-_cpusched=${_cpusched-cachyos}
+: "${_cpusched:=cachyos}"
 
 ### Tweak kernel options prior to a build via nconfig
-_makenconfig=${_makenconfig-}
+: "${_makenconfig:=}"
 
 ### Tweak kernel options prior to a build via menuconfig
-_makemenuconfig=${_makemenuconfig-}
+: "${_makemenuconfig:=}"
 
 ### Tweak kernel options prior to a build via xconfig
-_makexconfig=${_makexconfig-}
+: "${_makexconfig:=}"
 
 ### Tweak kernel options prior to a build via gconfig
-_makegconfig=${_makegconfig-}
+: "${_makegconfig:=}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-_NUMAdisable=${_NUMAdisable-}
+: "${_NUMAdisable:=}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,36 +48,36 @@ _NUMAdisable=${_NUMAdisable-}
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-_localmodcfg=${_localmodcfg-}
+: "${_localmodcfg:=}"
 
 # Path to the list of used modules
-_localmodcfg_path=${_localmodcfg_path-"$HOME/.config/modprobed.db"}
+: "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
 
 # Use the current kernel's .config file
 # Enabling this option will use the .config of the RUNNING kernel rather than
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-_use_current=${_use_current-}
+: "${_use_current:=}"
 
 ### Enable KBUILD_CFLAGS -O3
-_cc_harder=${_cc_harder-y}
+: "${_cc_harder:=y}"
 
 ### Set performance governor as default
-_per_gov=${_per_gov-}
+: "${_per_gov:=}"
 
 ### Enable TCP_CONG_BBR3
-_tcp_bbr3=${_tcp_bbr3-}
+: "${_tcp_bbr3:=}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
-_HZ_ticks=${_HZ_ticks-1000}
+: "${_HZ_ticks:=1000}"
 
 ## Choose between perodic, idle or full
 ### Full tickless can give higher performances in various cases but, depending on hardware, lower consistency.
-_tickrate=${_tickrate-full}
+: "${_tickrate:=full}"
 
 ## Choose between full(low-latency), voluntary or server
-_preempt=${_preempt-full}
+: "${_preempt:=full}"
 
 ### Transparent Hugepages
 # ATTENTION - one of two predefined values should be selected!
@@ -85,7 +85,7 @@ _preempt=${_preempt-full}
 # 'madvise' - madvise, prevent applications from allocating more memory resources than necessary
 # More infos here:
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/performance_tuning_guide/sect-red_hat_enterprise_linux-performance_tuning_guide-configuring_transparent_huge_pages
-_hugepage=${_hugepage-always}
+: "${_hugepage:=always}"
 
 # CPU compiler optimizations - Defaults to prompt at kernel config if left empty
 # AMD CPUs : "k8" "k8sse3" "k10" "barcelona" "bobcat" "jaguar" "bulldozer" "piledriver" "steamroller" "excavator" "zen" "zen2" "zen3" "zen4"
@@ -95,51 +95,51 @@ _hugepage=${_hugepage-always}
 # - "native_intel" (use compiler autodetection and will prompt for P6_NOPS - Selecting your arch manually in the list above is recommended instead of this option)
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 #
-_processor_opt=${_processor_opt-}
+: "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-_use_auto_optimization=${_use_auto_optimization-y}
+: "${_use_auto_optimization:=y}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
 # "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
 # "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
 # "none: disable LTO
-_use_llvm_lto=${_use_llvm_lto-thin}
+: "${_use_llvm_lto:=thin}"
 
 # Use suffix -lto only when requested by the user
 # y - enable -lto suffix
 # n - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-_use_lto_suffix=${_use_lto_suffix-}
+: "${_use_lto_suffix:=}"
 
 # Use suffix -gcc when requested by the user
 # Enabled by default to show the difference between LTO kernels and GCC kernels
-_use_gcc_suffix=${_use_gcc_suffix-y}
+: "${_use_gcc_suffix:=y}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-_use_kcfi=${_use_kcfi-}
+: "${_use_kcfi:=}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-_build_zfs=${_build_zfs-}
+: "${_build_zfs:=}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-_build_nvidia=${_build_nvidia-}
+: "${_build_nvidia:=}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-_build_nvidia_open=${_build_nvidia_open-}
+: "${_build_nvidia_open:=}"
 
 # Build a debug package with non-stripped vmlinux
-_build_debug=${_build_debug-}
+: "${_build_debug:=}"
 
 # Enable AUTOFDO_CLANG for the first compilation to create a kernel, which can be used for profiling
 # Workflow:
@@ -149,10 +149,10 @@ _build_debug=${_build_debug-}
 # 3. Profile the kernel and convert the profile, see Generating the Profile for AutoFDO
 # 4. Put the profile into the sourcedir
 # 5. Run kernel build again with the _autofdo_profile_name path to profile specified
-_autofdo=${_autofdo-}
+: "${_autofdo:=}"
 
 # Name for the AutoFDO profile
-_autofdo_profile_name=${_autofdo_profile_name-}
+: "${_autofdo_profile_name:=}"
 
 
 # ATTENTION: Do not modify after this line

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -9,7 +9,7 @@
 # Set these variables to ANYTHING that is not null or choose proper variable to enable them
 
 ### Selecting CachyOS config
-: "${_cachy_config:=y}"
+: "${_cachy_config:=yes}"
 
 ### Selecting the CPU scheduler
 # ATTENTION - only one of the following values can be selected:
@@ -23,22 +23,22 @@
 : "${_cpusched:=cachyos}"
 
 ### Tweak kernel options prior to a build via nconfig
-: "${_makenconfig:=}"
+: "${_makenconfig:=no}"
 
 ### Tweak kernel options prior to a build via menuconfig
-: "${_makemenuconfig:=}"
+: "${_makemenuconfig:=no}"
 
 ### Tweak kernel options prior to a build via xconfig
-: "${_makexconfig:=}"
+: "${_makexconfig:=no}"
 
 ### Tweak kernel options prior to a build via gconfig
-: "${_makegconfig:=}"
+: "${_makegconfig:=no}"
 
 # NUMA is optimized for multi-socket motherboards.
 # A single multi-core CPU actually runs slower with NUMA enabled.
 # See, https://bugs.archlinux.org/task/31187
 # It seems that in 2023 this is not really a huge regression anymore
-: "${_NUMAdisable:=}"
+: "${_NUMAdisable:=no}"
 
 # Compile ONLY used modules to VASTLYreduce the number of modules built
 # and the build time.
@@ -48,7 +48,7 @@
 # This PKGBUILD read the database kept if it exists
 #
 # More at this wiki page ---> https://wiki.archlinux.org/index.php/Modprobed-db
-: "${_localmodcfg:=}"
+: "${_localmodcfg:=no}"
 
 # Path to the list of used modules
 : "${_localmodcfg_path:="$HOME/.config/modprobed.db"}"
@@ -58,16 +58,16 @@
 # the ARCH defaults. Useful when the package gets updated and you already went
 # through the trouble of customizing your config options.  NOT recommended when
 # a new kernel is released, but again, convenient for package bumps.
-: "${_use_current:=}"
+: "${_use_current:=no}"
 
 ### Enable KBUILD_CFLAGS -O3
-: "${_cc_harder:=y}"
+: "${_cc_harder:=yes}"
 
 ### Set performance governor as default
-: "${_per_gov:=}"
+: "${_per_gov:=no}"
 
 ### Enable TCP_CONG_BBR3
-: "${_tcp_bbr3:=}"
+: "${_tcp_bbr3:=no}"
 
 ### Running with a 1000HZ, 750Hz, 625Hz, 600 Hz, 500Hz, 300Hz, 250Hz and 100Hz tick rate
 : "${_HZ_ticks:=1000}"
@@ -98,7 +98,7 @@
 : "${_processor_opt:=}"
 
 # This does automatically detect your supported CPU and optimizes for it
-: "${_use_auto_optimization:=y}"
+: "${_use_auto_optimization:=yes}"
 
 # Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
 # ATTENTION - one of three predefined values should be selected!
@@ -108,48 +108,48 @@
 : "${_use_llvm_lto:=thin}"
 
 # Use suffix -lto only when requested by the user
-# y - enable -lto suffix
-# n - disable -lto suffix
+# yes - enable -lto suffix
+# nno - disable -lto suffix
 # https://github.com/CachyOS/linux-cachyos/issues/36
-: "${_use_lto_suffix:=}"
+: "${_use_lto_suffix:=no}"
 
 # Use suffix -gcc when requested by the user
 # Enabled by default to show the difference between LTO kernels and GCC kernels
-: "${_use_gcc_suffix:=y}"
+: "${_use_gcc_suffix:=yes}"
 
 # KCFI is a proposed forward-edge control-flow integrity scheme for
 # Clang, which is more suitable for kernel use than the existing CFI
 # scheme used by CONFIG_CFI_CLANG. kCFI doesn't require LTO, doesn't
 # alter function references to point to a jump table, and won't break
 # function address equality.
-: "${_use_kcfi:=}"
+: "${_use_kcfi:=no}"
 
 # Build the zfs module in to the kernel
 # WARNING: The ZFS module doesn't build with selected RT sched due to licensing issues.
 # If you use ZFS, refrain from building the RT kernel
-: "${_build_zfs:=}"
+: "${_build_zfs:=no}"
 
 # Builds the nvidia module and package it into a own base
 # This does replace the requirement of nvidia-dkms
-: "${_build_nvidia:=}"
+: "${_build_nvidia:=no}"
 
 # Builds the open nvidia module and package it into a own base
 # This does replace the requirement of nvidia-open-dkms
 # Use this only if you have Turing+ GPU
-: "${_build_nvidia_open:=}"
+: "${_build_nvidia_open:=no}"
 
 # Build a debug package with non-stripped vmlinux
-: "${_build_debug:=}"
+: "${_build_debug:=no}"
 
 # Enable AUTOFDO_CLANG for the first compilation to create a kernel, which can be used for profiling
 # Workflow:
 # https://cachyos.org/blog/2411-kernel-autofdo/
-# 1. Compile Kernel with _autofdo=y and _build_debug=y
+# 1. Compile Kernel with _autofdo=yes and _build_debug=yes
 # 2. Boot the kernel in QEMU or on your system, see Workload
 # 3. Profile the kernel and convert the profile, see Generating the Profile for AutoFDO
 # 4. Put the profile into the sourcedir
 # 5. Run kernel build again with the _autofdo_profile_name path to profile specified
-: "${_autofdo:=}"
+: "${_autofdo:=no}"
 
 # Name for the AutoFDO profile
 : "${_autofdo_profile_name:=}"
@@ -161,9 +161,9 @@ _is_lto_kernel() {
     return $?
 }
 
-if _is_lto_kernel && [ "$_use_lto_suffix" = "y"  ]; then
+if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix=cachyos-lto
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "y" ]; then
+elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix=cachyos-gcc
 else
     _pkgsuffix=cachyos
@@ -229,18 +229,18 @@ if [[ "$_cpusched" = "rt" || "$_cpusched" = "rt-bore" ]]; then
 fi
 
 # ZFS support
-if [ -n "$_build_zfs" ]; then
+if [ "$_build_zfs" = "yes" ]; then
     makedepends+=(git)
     source+=("git+https://github.com/cachyos/zfs.git#commit=e65f69e41f4a276d7d0d1800a2878308a0ba84a6")
 fi
 
 # NVIDIA pre-build module support
-if [ -n "$_build_nvidia" ]; then
+if [ "$_build_nvidia" = "yes" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch")
 fi
 
-if [ -n "$_build_nvidia_open" ]; then
+if [ "$_build_nvidia_open" = "yes" ]; then
     source+=("nvidia-open-${_nv_ver}.tar.gz::https://github.com/NVIDIA/open-gpu-kernel-modules/archive/refs/tags/${_nv_ver}.tar.gz"
              "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch"
              "${_patchsource}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch"
@@ -250,7 +250,7 @@ if [ -n "$_build_nvidia_open" ]; then
 fi
 
 # Use generated AutoFDO Profile
-if [ -n "$_autofdo" ] && [ -n "$_autofdo_profile_name" ]; then
+if [ "$_autofdo" = "yes" ] && [ -n "$_autofdo_profile_name" ]; then
     if [ -e "$_autofdo_profile_name" ]; then
         source+=("$_autofdo_profile_name")
     else
@@ -316,19 +316,17 @@ prepare() {
     fi
 
     ### Use autooptimization
-    if [ -n "$_use_auto_optimization" ]; then
+    if [ "$_use_auto_optimization" = "yes" ]; then
         "${srcdir}"/auto-cpu-optimization.sh
     fi
 
     ### Selecting CachyOS config
-    if [ -n "$_cachy_config" ]; then
+    if [ "$_cachy_config" = "yes" ]; then
         echo "Enabling CachyOS config..."
         scripts/config -e CACHY
     fi
 
     ### Selecting the CPU scheduler
-    [ -z "$_cpusched" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_cpusched" in
         cachyos|bore|hardened) scripts/config -e SCHED_BORE;;
         bmq) scripts/config -e SCHED_ALT -e SCHED_BMQ;;
@@ -341,14 +339,12 @@ prepare() {
     echo "Selecting ${_cpusched^^} CPU scheduler..."
 
     ### Enable KCFI
-    if [ -n "$_use_kcfi" ]; then
+    if [ "$_use_kcfi" = "yes" ]; then
         echo "Enabling kCFI"
         scripts/config -e ARCH_SUPPORTS_CFI_CLANG -e CFI_CLANG -e CFI_AUTO_DEFAULT
     fi
 
     ### Select LLVM level
-    [ -z "$_use_llvm_lto" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_use_llvm_lto" in
         thin) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -d LTO_CLANG_FULL -e LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
         full) scripts/config -e LTO -e LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG -e ARCH_SUPPORTS_LTO_CLANG_THIN -d LTO_NONE -e HAS_LTO_CLANG -e LTO_CLANG_FULL -d LTO_CLANG_THIN -e HAVE_GCC_PLUGINS;;
@@ -359,8 +355,6 @@ prepare() {
     echo "Selecting '$_use_llvm_lto' LLVM level..."
 
     ### Select tick rate
-    [ -z "$_HZ_ticks" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_HZ_ticks" in
         100|250|500|600|625|750|1000)
             scripts/config -d HZ_300 -e "HZ_${_HZ_ticks}" --set-val HZ "${_HZ_ticks}";;
@@ -373,7 +367,7 @@ prepare() {
     echo "Setting tick rate to ${_HZ_ticks}Hz..."
 
     ### Disable NUMA
-    if [ -n "$_NUMAdisable" ]; then
+    if [ "$_NUMAdisable" = "yes" ]; then
         echo "Disabling NUMA from kernel config..."
         scripts/config -d NUMA \
             -d AMD_NUMA \
@@ -391,15 +385,13 @@ prepare() {
     fi
 
     ### Select performance governor
-    if [ -n "$_per_gov" ]; then
+    if [ "$_per_gov" = "yes" ]; then
         echo "Setting performance governor..."
         scripts/config -d CPU_FREQ_DEFAULT_GOV_SCHEDUTIL \
             -e CPU_FREQ_DEFAULT_GOV_PERFORMANCE
     fi
 
     ### Select tick type
-    [ -z "$_tickrate" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_tickrate" in
         perodic) scripts/config -d NO_HZ_IDLE -d NO_HZ_FULL -d NO_HZ -d NO_HZ_COMMON -e HZ_PERIODIC;;
         idle) scripts/config -d HZ_PERIODIC -d NO_HZ_FULL -e NO_HZ_IDLE  -e NO_HZ -e NO_HZ_COMMON;;
@@ -413,8 +405,6 @@ prepare() {
 
     # We should not set up the PREEMPT for RT kernels
     if [[ "$_cpusched" != "rt" || "$_cpusched" != "rt-bore" ]]; then
-        [ -z "$_preempt" ] && _die "The value is empty. Choose the correct one again."
-
         case "$_preempt" in
             full) scripts/config -e PREEMPT_BUILD -d PREEMPT_NONE -d PREEMPT_VOLUNTARY -e PREEMPT -e PREEMPT_COUNT -e PREEMPTION -e PREEMPT_DYNAMIC;;
             voluntary) scripts/config -e PREEMPT_BUILD -d PREEMPT_NONE -e PREEMPT_VOLUNTARY -d PREEMPT -e PREEMPT_COUNT -e PREEMPTION -d PREEMPT_DYNAMIC;;
@@ -426,7 +416,7 @@ prepare() {
     fi
 
     ### Enable O3
-    if [ -n "$_cc_harder" ] && [ -z "$_cc_size" ]; then
+    if [ "$_cc_harder" = "yes" ]; then
         echo "Enabling KBUILD_CFLAGS -O3..."
         scripts/config -d CC_OPTIMIZE_FOR_PERFORMANCE \
             -e CC_OPTIMIZE_FOR_PERFORMANCE_O3
@@ -449,7 +439,7 @@ prepare() {
     fi
 
     ### Enable bbr3
-    if [ -n "$_tcp_bbr3" ]; then
+    if [ "$_tcp_bbr3" = "yes" ]; then
         echo "Disabling TCP_CONG_CUBIC..."
         scripts/config -m TCP_CONG_CUBIC \
             -d DEFAULT_CUBIC \
@@ -463,8 +453,6 @@ prepare() {
     fi
 
     ### Select THP
-    [ -z "$_hugepage" ] && _die "The value is empty. Choose the correct one again."
-
     case "$_hugepage" in
         always) scripts/config -d TRANSPARENT_HUGEPAGE_MADVISE -e TRANSPARENT_HUGEPAGE_ALWAYS;;
         madvise) scripts/config -d TRANSPARENT_HUGEPAGE_ALWAYS -e TRANSPARENT_HUGEPAGE_MADVISE;;
@@ -475,11 +463,11 @@ prepare() {
 
     # Enable Clang AutoFDO
     # Add additonal check if Thin or Full LTO is enabled otherwise die
-    if [ -n "$_autofdo" ]; then
+    if [ "$_autofdo" = "yes" ]; then
         scripts/config -e AUTOFDO_CLANG
     fi
 
-    if [ -n "$_autofdo" ] && [ -n "$_autofdo_profile_name" ]; then
+    if [ "$_autofdo" = "yes" ] && [ -n "$_autofdo_profile_name" ]; then
         echo "AutoFDO profile has been found..."
         BUILD_FLAGS+=(CLANG_AUTOFDO_PROFILE="${srcdir}/${_autofdo_profile_name}")
     fi
@@ -489,7 +477,7 @@ prepare() {
 
     ### Optionally use running kernel's config
     # code originally by nous; http://aur.archlinux.org/packages.php?ID=40191
-    if [ -n "$_use_current" ]; then
+    if [ "$_use_current" = "yes" ]; then
         if [[ -s /proc/config.gz ]]; then
             echo "Extracting config from /proc/config.gz..."
             # modprobe configs
@@ -502,10 +490,9 @@ prepare() {
         fi
     fi
 
-
     ### Optionally load needed modules for the make localmodconfig
     # See https://aur.archlinux.org/packages/modprobed-db
-    if [ -n "$_localmodcfg" ]; then
+    if [ "$_localmodcfg" = "yes" ]; then
         if [ -e "$_localmodcfg_path" ]; then
             echo "Running Steven Rostedt's make localmodconfig now"
             make "${BUILD_FLAGS[@]}" LSMOD="${_localmodcfg_path}" localmodconfig
@@ -525,23 +512,23 @@ prepare() {
     echo "Prepared $pkgbase version $(<version)"
 
     ### Running make nconfig
-    [[ -z "$_makenconfig" ]] ||  make "${BUILD_FLAGS[@]}" nconfig
+    [ "$_makenconfig" = "yes" ] && make "${BUILD_FLAGS[@]}" nconfig
 
     ### Running make menuconfig
-    [[ -z "$_makemenuconfig" ]] ||  make "${BUILD_FLAGS[@]}" menuconfig
+    [ "$_makemenuconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" menuconfig
 
     ### Running make xconfig
-    [[ -z "$_makexconfig" ]] ||  make "${BUILD_FLAGS[@]}" xconfig
+    [ "$_makexconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" xconfig
 
     ### Running make gconfig
-    [[ -z "$_makegconfig" ]] ||  make "${BUILD_FLAGS[@]}" gconfig
+    [ "$_makegconfig" = "yes" ] &&  make "${BUILD_FLAGS[@]}" gconfig
 
     ### Save configuration for later reuse
     echo "Save configuration for later reuse..."
     local basedir="$(dirname "$(readlink "${srcdir}/config")")"
     cat .config > "${basedir}/config-${pkgver}-${pkgrel}${pkgbase#linux}"
 
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         cd "${srcdir}"
         sh "${_nv_pkg}.run" --extract-only
 
@@ -549,7 +536,7 @@ prepare() {
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_pkg}/kernel"
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_open_pkg}/kernel-open"
         # Fix for Zen5 error print in dmesg
         patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch" -d "${srcdir}/${_nv_open_pkg}"
@@ -573,20 +560,20 @@ build() {
        SYSSRC="${srcdir}/${_srcname}"
        SYSOUT="${srcdir}/${_srcname}"
     )
-    if [ -n "$_build_nvidia" ]; then
+    if [ "$_build_nvidia" = "yes" ]; then
         MODULE_FLAGS+=(NV_EXCLUDE_BUILD_MODULES='__EXCLUDE_MODULES')
         cd "${srcdir}/${_nv_pkg}/kernel"
         make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
 
     fi
 
-    if [ -n "$_build_nvidia_open" ]; then
+    if [ "$_build_nvidia_open" = "yes" ]; then
         cd "${srcdir}/${_nv_open_pkg}"
         MODULE_FLAGS+=(IGNORE_CC_MISMATCH=yes)
         CFLAGS= CXXFLAGS= LDFLAGS= make "${BUILD_FLAGS[@]}" "${MODULE_FLAGS[@]}" -j"$(nproc)" modules
     fi
 
-    if [ -n "$_build_zfs" ]; then
+    if [ "$_build_zfs" = "yes" ]; then
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
@@ -782,11 +769,11 @@ _package-nvidia-open(){
 }
 
 pkgname=("$pkgbase")
-[ -n "$_build_debug" ] && pkgname+=("$pkgbase-dbg")
+[ "$_build_debug" = "yes" ] && pkgname+=("$pkgbase-dbg")
 pkgname+=("$pkgbase-headers")
-[ -n "$_build_zfs" ] && pkgname+=("$pkgbase-zfs")
-[ -n "$_build_nvidia" ] && pkgname+=("$pkgbase-nvidia")
-[ -n "$_build_nvidia_open" ] && pkgname+=("$pkgbase-nvidia-open")
+[ "$_build_zfs" = "yes" ] && pkgname+=("$pkgbase-zfs")
+[ "$_build_nvidia" = "yes" ] && pkgname+=("$pkgbase-nvidia")
+[ "$_build_nvidia_open" = "yes" ] && pkgname+=("$pkgbase-nvidia-open")
 for _p in "${pkgname[@]}"; do
     eval "package_$_p() {
     $(declare -f "_package${_p#$pkgbase}")

--- a/script-v3-v4.sh
+++ b/script-v3-v4.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_auto_optimization-y/_use_auto_optimization-/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_auto_optimization:=yes/_use_auto_optimization:=no/" {}
 ## Enable ZFS
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_zfs-/_build_zfs-y/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_zfs:=no/_build_zfs:=yes/" {}
 ## Enable Generic v3
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_processor_opt-/_processor_opt-GENERIC_V3/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_processor_opt:=/_processor_opt:=GENERIC_V3/" {}
 ## Enable NVIDIA module
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia-/_build_nvidia-y/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia:=no/_build_nvidia:=yes/" {}
 ## Enable Open NVIDIA module
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia_open-/_build_nvidia_open-y/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia_open:=no/_build_nvidia_open:=yes/" {}
 ## Disable clang-LTO
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_llvm_lto-thin/_use_llvm_lto-none/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_llvm_lto:=thin/_use_llvm_lto:=none/" {}
 
 ## GCC v3 Kernel
 
@@ -25,7 +25,7 @@ do
 done
 
 ## LLVM ThinLTO v3 Kernel
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_llvm_lto-none/_use_llvm_lto-thin/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_llvm_lto:=none/_use_llvm_lto:=thin/" {}
 
 files=$(find . -name "PKGBUILD")
 
@@ -45,8 +45,8 @@ RUST_LOG=trace repo-manage-util -p cachyos-v3 update
 RUST_LOG=trace repo-manage-util -p cachyos-v3 update
 
 ## GCC v4 Kernel
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_llvm_lto-thin/_use_llvm_lto-none/" {}
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_processor_opt-GENERIC_V3/_processor_opt-GENERIC_V4/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_llvm_lto:=thin/_use_llvm_lto:=none/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_processor_opt:=GENERIC_V3/_processor_opt:=GENERIC_V4/" {}
 
 files=$(find . -name "PKGBUILD")
 
@@ -60,7 +60,7 @@ do
 done
 
 ## LLVM ThinLTO v4 Kernel
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_llvm_lto-none/_use_llvm_lto-thin/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_llvm_lto:=none/_use_llvm_lto:=thin/" {}
 
 files=$(find . -name "PKGBUILD")
 

--- a/script-znver4.sh
+++ b/script-znver4.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_auto_optimization-y/_use_auto_optimization-/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_auto_optimization:=yes/_use_auto_optimization:=no/" {}
 ## Enable ZFS
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_zfs-/_build_zfs-y/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_zfs:=no/_build_zfs:=yes/" {}
 ## Enable Zen 4
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_processor_opt-/_processor_opt-zen4/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_processor_opt:=/_processor_opt:=zen4/" {}
 ## Enable NVIDIA module
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia-/_build_nvidia-y/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia:=no/_build_nvidia:=yes/" {}
 ## Enable Open NVIDIA module
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia_open-/_build_nvidia_open-y/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia_open:=no/_build_nvidia_open:=yes/" {}
 
 ## GCC znver4 Kernel
 

--- a/script.sh
+++ b/script.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_auto_optimization-y/_use_auto_optimization-/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_auto_optimization:=yes/_use_auto_optimization:=no/" {}
 ## Enable ZFS
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_zfs-/_build_zfs-y/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_zfs:=no/_build_zfs:=yes/" {}
 ## Enable NVIDIA module
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia-/_build_nvidia-y/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia:=no/_build_nvidia:=yes/" {}
 ## Enable Open NVIDIA module
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia_open-/_build_nvidia_open-y/" {}
+find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia_open:=no/_build_nvidia_open:=yes/" {}
 
 files=$(find . -name "PKGBUILD")
 


### PR DESCRIPTION
It allows to get rid of duplicating the variable name, which helps to avoid typical typo errors and looks prettier.