### PR TITLE
linux-cachyos-rc: Update NVIDIA patches

### DIFF
--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -237,7 +237,10 @@ fi
 # NVIDIA pre-build module support
 if [ -n "$_build_nvidia" ]; then
     source+=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${_nv_ver}/${_nv_pkg}.run"
-             "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch")
+             "${_patchsource}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch"
+             "${_patchsource}/misc/nvidia/0008-Kbuild-Use-absolute-paths-for-symbolic-links.patch"
+             "${_patchsource}/misc/nvidia/0009-FROM-AOSC-Use-linux-aperture.c-for-removing-conflict.patch"
+             "${_patchsource}/misc/nvidia/0010-FROM-AOSC-TTM-fbdev-emulation-for-Linux-6.13.patch")
 fi
 
 if [ -n "$_build_nvidia_open" ]; then
@@ -247,9 +250,11 @@ if [ -n "$_build_nvidia_open" ]; then
              "${_patchsource}/misc/nvidia/0003-Add-IBT-Support.patch"
              "${_patchsource}/misc/nvidia/0004-silence-event-assert-until-570.patch"
              "${_patchsource}/misc/nvidia/0005-nvkms-Sanitize-trim-ELD-product-name-strings.patch"
-             "${_patchsource}/misc/nvidia/0007-6.13-Fix-for-modules-symlinking.patch"
-             "${_patchsource}/misc/nvidia/0008-crypto-Add-fix-for-6.13-Module-compilation.patch"
-             "${_patchsource}/misc/nvidia/0009-nvidia-nv-Convert-symbol-namespace-to-string-literal.patch")
+             "${_patchsource}/misc/nvidia/0006-crypto-Add-fix-for-6.13-Module-compilation.patch"
+             "${_patchsource}/misc/nvidia/0007-nvidia-nv-Convert-symbol-namespace-to-string-literal.patch"
+             "${_patchsource}/misc/nvidia/0008-Kbuild-Use-absolute-paths-for-symbolic-links.patch"
+             "${_patchsource}/misc/nvidia/0009-FROM-AOSC-Use-linux-aperture.c-for-removing-conflict.patch"
+             "${_patchsource}/misc/nvidia/0010-FROM-AOSC-TTM-fbdev-emulation-for-Linux-6.13.patch")
 fi
 
 # Use generated AutoFDO Profile
@@ -549,22 +554,48 @@ prepare() {
 
         # Use fbdev and modeset as default
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_pkg}/kernel"
+
+        # https://github.com/NVIDIA/open-gpu-kernel-modules/issues/747
+        patch -Np2 -i "${srcdir}/0008-Kbuild-Use-absolute-paths-for-symbolic-links.patch" -d "${srcdir}/${_nv_pkg}/kernel"
+
+        # Fixes fbdev on 6.13+
+        # https://github.com/NVIDIA/open-gpu-kernel-modules/issues/749
+        # https://gist.github.com/xtexChooser/da92d9df902788b75f746f348552ae80
+        patch -Np2 -i "${srcdir}/0009-FROM-AOSC-Use-linux-aperture.c-for-removing-conflict.patch" -d "${srcdir}/${_nv_pkg}/kernel"
+        patch -Np2 -i "${srcdir}/0010-FROM-AOSC-TTM-fbdev-emulation-for-Linux-6.13.patch" -d "${srcdir}/${_nv_pkg}/kernel"
     fi
 
     if [ -n "$_build_nvidia_open" ]; then
+        # Use fbdev and modeset as default
         patch -Np1 -i "${srcdir}/0001-Make-modeset-and-fbdev-default-enabled.patch" -d "${srcdir}/${_nv_open_pkg}/kernel-open"
+
         # Fix for Zen5 error print in dmesg
         patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch" -d "${srcdir}/${_nv_open_pkg}"
+
         # Fix for https://bugs.archlinux.org/task/74886
         patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0003-Add-IBT-Support.patch" -d "${srcdir}/${_nv_open_pkg}"
+
         # Fix for CS2 dmesg spam
         patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0004-silence-event-assert-until-570.patch" -d "${srcdir}/${_nv_open_pkg}"
+
         # Fix for HDMI names
         patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0005-nvkms-Sanitize-trim-ELD-product-name-strings.patch" -d "${srcdir}/${_nv_open_pkg}"
-        # Add fix for 6.13 Module Compilation
-        patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0007-6.13-Fix-for-modules-symlinking.patch" -d "${srcdir}/${_nv_open_pkg}"
-        patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0008-crypto-Add-fix-for-6.13-Module-compilation.patch" -d "${srcdir}/${_nv_open_pkg}"
-        patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0009-nvidia-nv-Convert-symbol-namespace-to-string-literal.patch" -d "${srcdir}/${_nv_open_pkg}"
+
+        # Fix build errors on 6.13+
+        # https://github.com/NVIDIA/open-gpu-kernel-modules/issues/746
+        patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0006-crypto-Add-fix-for-6.13-Module-compilation.patch" -d "${srcdir}/${_nv_open_pkg}"
+
+        # https://github.com/NVIDIA/open-gpu-kernel-modules/issues/751
+        patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0007-nvidia-nv-Convert-symbol-namespace-to-string-literal.patch" -d "${srcdir}/${_nv_open_pkg}"
+
+        # https://github.com/NVIDIA/open-gpu-kernel-modules/issues/747
+        patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0008-Kbuild-Use-absolute-paths-for-symbolic-links.patch" -d "${srcdir}/${_nv_open_pkg}"
+
+        # Fixes fbdev on 6.13+
+        # https://github.com/NVIDIA/open-gpu-kernel-modules/issues/749
+        # https://gist.github.com/xtexChooser/da92d9df902788b75f746f348552ae80
+        patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0009-FROM-AOSC-Use-linux-aperture.c-for-removing-conflict.patch" -d "${srcdir}/${_nv_open_pkg}"
+        patch -Np1 --no-backup-if-mismatch -i "${srcdir}/0010-FROM-AOSC-TTM-fbdev-emulation-for-Linux-6.13.patch" -d "${srcdir}/${_nv_open_pkg}"
     fi
 }
 


### PR DESCRIPTION
This adds fixes for nvidia-drm.fbdev in 6.13 and finally enables support for the prebuilt closed module.

Patches are based on the latest HEAD of [1] at the time of writing. Patches have also been pushed to the `staging` branch of [2] and will be merged in tandem with this PR.

[1] https://github.com/CachyOS/open-gpu-kernel-modules/tree/565-cachyos
[2] https://github.com/CachyOS/kernel-patches/