### PR TITLE
PKGBUILD: Enable QR Code Panic for GCC compiled kernels

### DIFF
--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -358,6 +358,12 @@ prepare() {
 
     echo "Selecting '$_use_llvm_lto' LLVM level..."
 
+    if [ "$_use_llvm_lto" = "none" ]; then
+        echo "Enabling QR Code Panic for GCC Kernels"
+        scripts/config -e RUST_IS_AVAILABLE -e CONFIG_RUST -e RUST_FW_LOADER_ABSTRACTIONS -d CONFIG_BLK_DEV_RUST_NULL --set-str DRM_PANIC_SCREEN qr-code \
+        -e DRM_PANIC_SCREEN_QR_CODE --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# --set-str DRM_PANIC_SCREEN_QR_VERSION 40
+    fi
+
     ### Select tick rate
     case "$_HZ_ticks" in
         100|250|500|600|750|1000)
@@ -655,6 +661,12 @@ _package-headers() {
 
     echo "Installing KConfig files..."
     find . -name 'Kconfig*' -exec install -Dm644 {} "$builddir/{}" \;
+
+    if [ "$_use_llvm_lto" = "none" ]; then
+        echo "Installing Rust files..."
+        install -Dt "$builddir/rust" -m644 rust/*.rmeta
+        install -Dt "$builddir/rust" rust/*.so
+    fi
 
     echo "Installing unstripped VDSO..."
     make INSTALL_MOD_PATH="$pkgdir/usr" vdso_install \

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -196,6 +196,9 @@ makedepends=(
   pahole
   perl
   python
+  rust
+  rust-bindgen
+  rust-src
   tar
   xz
   zstd


### PR DESCRIPTION
This does enable the QR Code Panic Screen for GCC compiled kernels until LLVM (Thin) LTO does support it.

Not applied to all kernels yes, will do this after review