### PR TITLE
linux-cachyos-server: Build with NOHZ_FULL

### DIFF
--- a/linux-cachyos-server/PKGBUILD
+++ b/linux-cachyos-server/PKGBUILD
@@ -62,7 +62,7 @@
 
 ## Choose between perodic, idle or full
 ### Full tickless can give higher performances in various cases but, depending on hardware, lower consistency.
-: "${_tickrate:=idle}"
+: "${_tickrate:=full}"
 
 ## Choose between full(low-latency), lazy, voluntary or none
 : "${_preempt:=none}"


### PR DESCRIPTION
Some server workloads benefit from omitting ticks for certain CPUs. The default behaviour is also NOHZ_IDLE unless nohz_full=n is added to boot cmdline.

Closes: #461