### PR TITLE
linux-cachyos-rc: 6.16-rc5-1

### DIFF
--- a/linux-cachyos-rc/.SRCINFO
+++ b/linux-cachyos-rc/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = linux-cachyos-rc
 	pkgdesc = Linux BORE + LTO + AutoFDO + Propeller + Cachy Sauce Kernel by CachyOS with other patches and improvements - Release Candidate
-	pkgver = 6.16.rc4
-	pkgrel = 2
+	pkgver = 6.16.rc5
+	pkgrel = 1
 	url = https://github.com/CachyOS/linux-cachyos
 	arch = x86_64
 	license = GPL-2.0-only
@@ -21,13 +21,13 @@ pkgbase = linux-cachyos-rc
 	options = !strip
 	options = !debug
 	options = !lto
-	source = https://github.com/torvalds/linux/archive/refs/tags/v6.16-rc4.tar.gz
+	source = https://github.com/torvalds/linux/archive/refs/tags/v6.16-rc5.tar.gz
 	source = config
 	source = https://raw.githubusercontent.com/cachyos/kernel-patches/master/6.16/all/0001-cachyos-base-all.patch
 	source = https://raw.githubusercontent.com/cachyos/kernel-patches/master/6.16/sched/0001-bore-cachy.patch
-	b2sums = 2f9972c7309995b3ac07069126faae2365980a86f929553d1ffeb6317fc5ec8ed1f9f3dc97185a9502d760207e5e7a8f11c627b95fbc612a139ff4c26668005e
+	b2sums = b3fd7239db3b9f147e1b2394f8307433077059f01dad1b70359b5e1ca3ce00f961a2d24ca13f54ff1fed7fb8c9026c7684c0a506295c0c8052825e824a0e293b
 	b2sums = ee574961ecab0c20667d665cf8428d843bb449cbf46b9ad860edc0a6f28cc77695834e97fad7d177db49d3190591c7e35cf960bcb68236ec48ce774a9832dd74
-	b2sums = 9d03d43cb5d709badf3ad4cacc54b2cb2ebacbb1f43aa2e552975301d035dbad2988935838ecb69c4a006a70efffd5565474868a4657d355b45ee351acd13d6d
+	b2sums = 4039c6781aff9dd1f2dde131e327ec143d94abcf6a918bdf6178e265808c0e56f3581d52e45876702b4c440787c87fe5b846ede1c0e035b230c3f851dfce3c9c
 	b2sums = 162130c38d315b06fdb9f0b08d1df6b63c1cc44ee140df044665ff693ab3cde4f55117eed12253504184ccd379fc7f9142aa91c5334dff1a42dbd009f43d8897
 
 pkgname = linux-cachyos-rc

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -168,7 +168,7 @@ pkgbase="linux-$_pkgsuffix"
 _major=6.16
 _minor=0
 #_minorc=$((_minor+1))
-_rcver=rc4
+_rcver=rc5
 pkgver=${_major}.${_rcver}
 #_stable=${_major}.${_minor}
 #_stable=${_major}
@@ -176,7 +176,7 @@ _stable=${_major}-${_rcver}
 _srcname=linux-${_stable}
 #_srcname=linux-${_major}
 pkgdesc='Linux BORE + LTO + AutoFDO + Propeller + Cachy Sauce Kernel by CachyOS with other patches and improvements - Release Candidate'
-pkgrel=2
+pkgrel=1
 _kernver="$pkgver-$pkgrel"
 _kernuname="${pkgver}-${_pkgsuffix}"
 arch=('x86_64')
@@ -775,7 +775,7 @@ for _p in "${pkgname[@]}"; do
     }"
 done
 
-b2sums=('2f9972c7309995b3ac07069126faae2365980a86f929553d1ffeb6317fc5ec8ed1f9f3dc97185a9502d760207e5e7a8f11c627b95fbc612a139ff4c26668005e'
+b2sums=('b3fd7239db3b9f147e1b2394f8307433077059f01dad1b70359b5e1ca3ce00f961a2d24ca13f54ff1fed7fb8c9026c7684c0a506295c0c8052825e824a0e293b'
         'ee574961ecab0c20667d665cf8428d843bb449cbf46b9ad860edc0a6f28cc77695834e97fad7d177db49d3190591c7e35cf960bcb68236ec48ce774a9832dd74'
-        '9d03d43cb5d709badf3ad4cacc54b2cb2ebacbb1f43aa2e552975301d035dbad2988935838ecb69c4a006a70efffd5565474868a4657d355b45ee351acd13d6d'
+        '4039c6781aff9dd1f2dde131e327ec143d94abcf6a918bdf6178e265808c0e56f3581d52e45876702b4c440787c87fe5b846ede1c0e035b230c3f851dfce3c9c'
         '162130c38d315b06fdb9f0b08d1df6b63c1cc44ee140df044665ff693ab3cde4f55117eed12253504184ccd379fc7f9142aa91c5334dff1a42dbd009f43d8897')


### PR DESCRIPTION
A bit late here because of a DRM regression that occasionally prevented booting, and if it booted, the DE would crash after around ~10 minutes. In my case, both kwin and plasmashell crashed so keyboard shortcuts didn't work either.