### PR TITLE
Make kernel module signing more robust

### DIFF
--- a/linux-cachyos-bmq/PKGBUILD
+++ b/linux-cachyos-bmq/PKGBUILD
@@ -470,8 +470,11 @@ prepare() {
 _sign_modules() {
     msg2 "Signing modules in $1"
     local sign_script="${srcdir}/${_srcname}/scripts/sign-file"
-    local sign_key="${srcdir}/${_srcname}/$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
-    local sign_cert="$(echo "$sign_key" | sed 's/\.pem$/.x509/')"
+    local sign_key="$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
+    if [[ ! "$sign_key" =~ ^/ ]]; then
+        sign_key="${srcdir}/${_srcname}/${sign_key}"
+    fi
+    local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
     find "$1" -type f -name '*.ko' -print -exec \

--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -470,8 +470,11 @@ prepare() {
 _sign_modules() {
     msg2 "Signing modules in $1"
     local sign_script="${srcdir}/${_srcname}/scripts/sign-file"
-    local sign_key="${srcdir}/${_srcname}/$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
-    local sign_cert="$(echo "$sign_key" | sed 's/\.pem$/.x509/')"
+    local sign_key="$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
+    if [[ ! "$sign_key" =~ ^/ ]]; then
+        sign_key="${srcdir}/${_srcname}/${sign_key}"
+    fi
+    local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
     find "$1" -type f -name '*.ko' -print -exec \

--- a/linux-cachyos-deckify/PKGBUILD
+++ b/linux-cachyos-deckify/PKGBUILD
@@ -471,8 +471,11 @@ prepare() {
 _sign_modules() {
     msg2 "Signing modules in $1"
     local sign_script="${srcdir}/${_srcname}/scripts/sign-file"
-    local sign_key="${srcdir}/${_srcname}/$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
-    local sign_cert="$(echo "$sign_key" | sed 's/\.pem$/.x509/')"
+    local sign_key="$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
+    if [[ ! "$sign_key" =~ ^/ ]]; then
+        sign_key="${srcdir}/${_srcname}/${sign_key}"
+    fi
+    local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
     find "$1" -type f -name '*.ko' -print -exec \

--- a/linux-cachyos-eevdf/PKGBUILD
+++ b/linux-cachyos-eevdf/PKGBUILD
@@ -470,8 +470,11 @@ prepare() {
 _sign_modules() {
     msg2 "Signing modules in $1"
     local sign_script="${srcdir}/${_srcname}/scripts/sign-file"
-    local sign_key="${srcdir}/${_srcname}/$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
-    local sign_cert="$(echo "$sign_key" | sed 's/\.pem$/.x509/')"
+    local sign_key="$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
+    if [[ ! "$sign_key" =~ ^/ ]]; then
+        sign_key="${srcdir}/${_srcname}/${sign_key}"
+    fi
+    local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
     find "$1" -type f -name '*.ko' -print -exec \

--- a/linux-cachyos-hardened/PKGBUILD
+++ b/linux-cachyos-hardened/PKGBUILD
@@ -470,8 +470,11 @@ prepare() {
 _sign_modules() {
     msg2 "Signing modules in $1"
     local sign_script="${srcdir}/${_srcname}/scripts/sign-file"
-    local sign_key="${srcdir}/${_srcname}/$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
-    local sign_cert="$(echo "$sign_key" | sed 's/\.pem$/.x509/')"
+    local sign_key="$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
+    if [[ ! "$sign_key" =~ ^/ ]]; then
+        sign_key="${srcdir}/${_srcname}/${sign_key}"
+    fi
+    local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
     find "$1" -type f -name '*.ko' -print -exec \

--- a/linux-cachyos-lts/PKGBUILD
+++ b/linux-cachyos-lts/PKGBUILD
@@ -472,8 +472,11 @@ prepare() {
 _sign_modules() {
     msg2 "Signing modules in $1"
     local sign_script="${srcdir}/${_srcname}/scripts/sign-file"
-    local sign_key="${srcdir}/${_srcname}/$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
-    local sign_cert="$(echo "$sign_key" | sed 's/\.pem$/.x509/')"
+    local sign_key="$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
+    if [[ ! "$sign_key" =~ ^/ ]]; then
+        sign_key="${srcdir}/${_srcname}/${sign_key}"
+    fi
+    local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
     find "$1" -type f -name '*.ko' -print -exec \

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -533,8 +533,11 @@ prepare() {
 _sign_modules() {
     msg2 "Signing modules in $1"
     local sign_script="${srcdir}/${_srcname}/scripts/sign-file"
-    local sign_key="${srcdir}/${_srcname}/$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
-    local sign_cert="$(echo "$sign_key" | sed 's/\.pem$/.x509/')"
+    local sign_key="$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
+    if [[ ! "$sign_key" =~ ^/ ]]; then
+        sign_key="${srcdir}/${_srcname}/${sign_key}"
+    fi
+    local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
     find "$1" -type f -name '*.ko' -print -exec \

--- a/linux-cachyos-rt-bore/PKGBUILD
+++ b/linux-cachyos-rt-bore/PKGBUILD
@@ -470,8 +470,11 @@ prepare() {
 _sign_modules() {
     msg2 "Signing modules in $1"
     local sign_script="${srcdir}/${_srcname}/scripts/sign-file"
-    local sign_key="${srcdir}/${_srcname}/$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
-    local sign_cert="$(echo "$sign_key" | sed 's/\.pem$/.x509/')"
+    local sign_key="$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
+    if [[ ! "$sign_key" =~ ^/ ]]; then
+        sign_key="${srcdir}/${_srcname}/${sign_key}"
+    fi
+    local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
     find "$1" -type f -name '*.ko' -print -exec \

--- a/linux-cachyos-server/PKGBUILD
+++ b/linux-cachyos-server/PKGBUILD
@@ -470,8 +470,11 @@ prepare() {
 _sign_modules() {
     msg2 "Signing modules in $1"
     local sign_script="${srcdir}/${_srcname}/scripts/sign-file"
-    local sign_key="${srcdir}/${_srcname}/$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
-    local sign_cert="$(echo "$sign_key" | sed 's/\.pem$/.x509/')"
+    local sign_key="$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
+    if [[ ! "$sign_key" =~ ^/ ]]; then
+        sign_key="${srcdir}/${_srcname}/${sign_key}"
+    fi
+    local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
     find "$1" -type f -name '*.ko' -print -exec \

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -532,8 +532,11 @@ prepare() {
 _sign_modules() {
     msg2 "Signing modules in $1"
     local sign_script="${srcdir}/${_srcname}/scripts/sign-file"
-    local sign_key="${srcdir}/${_srcname}/$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
-    local sign_cert="$(echo "$sign_key" | sed 's/\.pem$/.x509/')"
+    local sign_key="$(grep -Po 'CONFIG_MODULE_SIG_KEY="\K[^"]*' "${srcdir}/${_srcname}/.config")"
+    if [[ ! "$sign_key" =~ ^/ ]]; then
+        sign_key="${srcdir}/${_srcname}/${sign_key}"
+    fi
+    local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
     find "$1" -type f -name '*.ko' -print -exec \


### PR DESCRIPTION
After re-reading kernel Makefiles more deeply, I realized the public key filename is actually hardcoded and not derived from the private key, so we should do the same

Further, this makes the key routine more robust, as it does take absolute paths, which the current method did not support