### PR TITLE
linux-cachyos-deckify: Flip handheld configs in PKGBUILD

### DIFF
--- a/linux-cachyos-deckify/PKGBUILD
+++ b/linux-cachyos-deckify/PKGBUILD
@@ -407,6 +407,9 @@ prepare() {
     echo "Enable USER_NS_UNPRIVILEGED"
     scripts/config -e USER_NS
 
+    echo "Enabling handheld configs"
+    scripts/config -d RCU_LAZY_DEFAULT_OFF -e AMD_PRIVATE_COLOR
+
     ### Optionally use running kernel's config
     # code originally by nous; http://aur.archlinux.org/packages.php?ID=40191
     if [ "$_use_current" = "yes" ]; then


### PR DESCRIPTION
Alot of the times during config updating, some handheld configs that are different from default don't get flipped back. These usually get caught after the fact, and if this isn't caught during review, issues like #585 pop up.

Fix this once and for all by explicitly configuring them in the PKGBUILD, that way no matter what is in the config file, we would always get the proper configuration.

This is currently just a quick hotfix, in the future I would like to add more config entries into this (for handheld drivers), and maybe making a PKGBUILD config variable for this if desirable.

Closes: #585