### PR TITLE
Use extramodules path to install NVIDIA modules

### DIFF
--- a/linux-cachyos-bmq/PKGBUILD
+++ b/linux-cachyos-bmq/PKGBUILD
@@ -665,7 +665,7 @@ _package-zfs(){
     license=('CDDL')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/zfs"
     install -dm755 "${modulesdir}"
@@ -684,7 +684,7 @@ _package-nvidia(){
     license=('custom')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_pkg}"
     install -dm755 "${modulesdir}"
@@ -703,7 +703,7 @@ _package-nvidia-open(){
     license=('MIT AND GPL-2.0-only')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_open_pkg}"
     install -dm755 "${modulesdir}"

--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -665,7 +665,7 @@ _package-zfs(){
     license=('CDDL')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/zfs"
     install -dm755 "${modulesdir}"
@@ -684,7 +684,7 @@ _package-nvidia(){
     license=('custom')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_pkg}"
     install -dm755 "${modulesdir}"
@@ -703,7 +703,7 @@ _package-nvidia-open(){
     license=('MIT AND GPL-2.0-only')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_open_pkg}"
     install -dm755 "${modulesdir}"

--- a/linux-cachyos-deckify/PKGBUILD
+++ b/linux-cachyos-deckify/PKGBUILD
@@ -669,7 +669,7 @@ _package-zfs(){
     license=('CDDL')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/zfs"
     install -dm755 "${modulesdir}"
@@ -688,7 +688,7 @@ _package-nvidia(){
     license=('custom')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_pkg}"
     install -dm755 "${modulesdir}"
@@ -707,7 +707,7 @@ _package-nvidia-open(){
     license=('MIT AND GPL-2.0-only')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_open_pkg}"
     install -dm755 "${modulesdir}"

--- a/linux-cachyos-eevdf/PKGBUILD
+++ b/linux-cachyos-eevdf/PKGBUILD
@@ -665,7 +665,7 @@ _package-zfs(){
     license=('CDDL')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/zfs"
     install -dm755 "${modulesdir}"
@@ -684,7 +684,7 @@ _package-nvidia(){
     license=('custom')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_pkg}"
     install -dm755 "${modulesdir}"
@@ -703,7 +703,7 @@ _package-nvidia-open(){
     license=('MIT AND GPL-2.0-only')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_open_pkg}"
     install -dm755 "${modulesdir}"

--- a/linux-cachyos-hardened/PKGBUILD
+++ b/linux-cachyos-hardened/PKGBUILD
@@ -664,7 +664,7 @@ _package-zfs(){
     license=('CDDL')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/zfs"
     install -dm755 "${modulesdir}"
@@ -683,7 +683,7 @@ _package-nvidia(){
     license=('custom')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_pkg}"
     install -dm755 "${modulesdir}"
@@ -702,7 +702,7 @@ _package-nvidia-open(){
     license=('MIT AND GPL-2.0-only')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_open_pkg}"
     install -dm755 "${modulesdir}"

--- a/linux-cachyos-lts/PKGBUILD
+++ b/linux-cachyos-lts/PKGBUILD
@@ -657,7 +657,7 @@ _package-zfs(){
     license=('CDDL')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/zfs"
     install -dm755 "${modulesdir}"
@@ -676,7 +676,7 @@ _package-nvidia(){
     license=('custom')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_pkg}"
     install -dm755 "${modulesdir}"
@@ -695,7 +695,7 @@ _package-nvidia-open(){
     license=('MIT AND GPL-2.0-only')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_open_pkg}"
     install -dm755 "${modulesdir}"

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -733,7 +733,7 @@ _package-zfs(){
     license=('CDDL')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/zfs"
     install -dm755 "${modulesdir}"
@@ -752,7 +752,7 @@ _package-nvidia(){
     license=('custom')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_pkg}"
     install -dm755 "${modulesdir}"
@@ -771,7 +771,7 @@ _package-nvidia-open(){
     license=('MIT AND GPL-2.0-only')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_open_pkg}"
     install -dm755 "${modulesdir}"

--- a/linux-cachyos-rt-bore/PKGBUILD
+++ b/linux-cachyos-rt-bore/PKGBUILD
@@ -665,7 +665,7 @@ _package-zfs(){
     license=('CDDL')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/zfs"
     install -dm755 "${modulesdir}"
@@ -684,7 +684,7 @@ _package-nvidia(){
     license=('custom')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_pkg}"
     install -dm755 "${modulesdir}"
@@ -703,7 +703,7 @@ _package-nvidia-open(){
     license=('MIT AND GPL-2.0-only')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_open_pkg}"
     install -dm755 "${modulesdir}"

--- a/linux-cachyos-server/PKGBUILD
+++ b/linux-cachyos-server/PKGBUILD
@@ -665,7 +665,7 @@ _package-zfs(){
     license=('CDDL')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/zfs"
     install -dm755 "${modulesdir}"
@@ -684,7 +684,7 @@ _package-nvidia(){
     license=('custom')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_pkg}"
     install -dm755 "${modulesdir}"
@@ -703,7 +703,7 @@ _package-nvidia-open(){
     license=('MIT AND GPL-2.0-only')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_open_pkg}"
     install -dm755 "${modulesdir}"

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -737,7 +737,7 @@ _package-zfs(){
     license=('CDDL')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/zfs"
     install -dm755 "${modulesdir}"
@@ -756,7 +756,7 @@ _package-nvidia(){
     license=('custom')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_pkg}"
     install -dm755 "${modulesdir}"
@@ -775,7 +775,7 @@ _package-nvidia-open(){
     license=('MIT AND GPL-2.0-only')
 
     cd "$_srcname"
-    local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
+    local modulesdir="$pkgdir/usr/lib/modules/$(<version)/extramodules"
 
     cd "${srcdir}/${_nv_open_pkg}"
     install -dm755 "${modulesdir}"


### PR DESCRIPTION
Since new mkinitcpio added a hook to update initramfs for external modules, we should use this path as well as the nvidia package to get rid of our own hook from cachyos-hooks.