### PR TITLE
update zfs for kernel 6.18 in linux-cachyos-rc

### DIFF
--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -228,7 +228,7 @@ fi
 # ZFS support
 if [ "$_build_zfs" = "yes" ]; then
     makedepends+=(git)
-    source+=("git+https://github.com/cachyos/zfs.git#commit=fe5ed524c72e0b2e2cd4c47ee5bc987290e89666")
+    source+=("git+https://github.com/cachyos/zfs.git#commit=d52214480c2659dc0ffbf0c4267166da8f5e3af9")
 fi
 
 # NVIDIA pre-build module support


### PR DESCRIPTION
Follows up https://github.com/CachyOS/zfs/pull/1 and https://github.com/CachyOS/zfs/pull/2