### PR TITLE
feat: add isp4 patches

### DIFF
--- a/linux-cachyos-bmq/PKGBUILD
+++ b/linux-cachyos-bmq/PKGBUILD
@@ -180,6 +180,13 @@ _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(
     "https://cdn.kernel.org/pub/linux/kernel/v${pkgver%%.*}.x/${_srcname}.tar.xz"
     "config"
+    "${_patchsource}/isp4/0001-amd-isp4.patch"
+    "${_patchsource}/isp4/0002-amd-isp4.patch"
+    "${_patchsource}/isp4/0003-amd-isp4.patch"
+    "${_patchsource}/isp4/0004-amd-isp4.patch"
+    "${_patchsource}/isp4/0005-amd-isp4.patch"
+    "${_patchsource}/isp4/0006-amd-isp4.patch"
+    "${_patchsource}/isp4/0007-amd-isp4.patch"
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
@@ -257,6 +264,10 @@ prepare() {
 
     echo "Setting config..."
     cp ../config .config
+
+    ### Enable AMD ISP4 Driver
+    echo "Enabling AMD ISP4 Driver..."
+    scripts/config -m AMD_ISP4
 
     ### Select CPU optimization
     if [ -n "$_processor_opt" ]; then
@@ -731,5 +742,12 @@ done
 
 b2sums=('1e8e226364a85f3fd66e51495a99a76e377389aa48c708953aaa28b6ec669f05aab6d240365965eec5643e2fa6aee15796005b2873e8fea748e432b1d799eabc'
         'bc863600b02ccb6404e95e85f31b1cbc1293c663e0dd96eb0b7f42277b937849f156f509e688862d6926711e2297712bce4fdbfc04231b104b2608b1fc1ba34b'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
         '39b60319ce157ad58d655c220d34ede65275ec5638e5fad4602d89aa9a93aaa17e2c2f00c0c978aa2b42056f5ea04e3319b44484cd8eeda16637c6cd0ed9c5d4'
         'd6059a9c1c8d70ca1f5adca6d03c623e296ebccfbee2898c6b5b92023629a6f2bcf20d41d039e1cba647ff76f4959c5426f740d9ad097d2a1a6a918d4ccc5eba')

--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -180,6 +180,13 @@ _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(
     "https://cdn.kernel.org/pub/linux/kernel/v${pkgver%%.*}.x/${_srcname}.tar.xz"
     "config"
+    "${_patchsource}/isp4/0001-amd-isp4.patch"
+    "${_patchsource}/isp4/0002-amd-isp4.patch"
+    "${_patchsource}/isp4/0003-amd-isp4.patch"
+    "${_patchsource}/isp4/0004-amd-isp4.patch"
+    "${_patchsource}/isp4/0005-amd-isp4.patch"
+    "${_patchsource}/isp4/0006-amd-isp4.patch"
+    "${_patchsource}/isp4/0007-amd-isp4.patch"
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
@@ -257,6 +264,10 @@ prepare() {
 
     echo "Setting config..."
     cp ../config .config
+
+    ### Enable AMD ISP4 Driver
+    echo "Enabling AMD ISP4 Driver..."
+    scripts/config -m AMD_ISP4
 
     ### Select CPU optimization
     if [ -n "$_processor_opt" ]; then
@@ -731,5 +742,12 @@ done
 
 b2sums=('1e8e226364a85f3fd66e51495a99a76e377389aa48c708953aaa28b6ec669f05aab6d240365965eec5643e2fa6aee15796005b2873e8fea748e432b1d799eabc'
         'bc863600b02ccb6404e95e85f31b1cbc1293c663e0dd96eb0b7f42277b937849f156f509e688862d6926711e2297712bce4fdbfc04231b104b2608b1fc1ba34b'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
         '39b60319ce157ad58d655c220d34ede65275ec5638e5fad4602d89aa9a93aaa17e2c2f00c0c978aa2b42056f5ea04e3319b44484cd8eeda16637c6cd0ed9c5d4'
         '966b8059310169dd0806bfad95d01b8587258113962064e3f0d7ee429bc010e62aaf201666a0c6ab7feb5f50b5aabe08b9e99cbac033c29140799bc5cb6178be')

--- a/linux-cachyos-deckify/PKGBUILD
+++ b/linux-cachyos-deckify/PKGBUILD
@@ -179,6 +179,13 @@ _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(
     "https://cdn.kernel.org/pub/linux/kernel/v${pkgver%%.*}.x/${_srcname}.tar.xz"
     "config"
+    "${_patchsource}/isp4/0001-amd-isp4.patch"
+    "${_patchsource}/isp4/0002-amd-isp4.patch"
+    "${_patchsource}/isp4/0003-amd-isp4.patch"
+    "${_patchsource}/isp4/0004-amd-isp4.patch"
+    "${_patchsource}/isp4/0005-amd-isp4.patch"
+    "${_patchsource}/isp4/0006-amd-isp4.patch"
+    "${_patchsource}/isp4/0007-amd-isp4.patch"
     "${_patchsource}/all/0001-cachyos-base-all.patch"
     "${_patchsource}/misc/0001-acpi-call.patch"
     "${_patchsource}/misc/0001-handheld.patch")
@@ -258,6 +265,10 @@ prepare() {
 
     echo "Setting config..."
     cp ../config .config
+
+    ### Enable AMD ISP4 Driver
+    echo "Enabling AMD ISP4 Driver..."
+    scripts/config -m AMD_ISP4
 
     ### Select CPU optimization
     if [ -n "$_processor_opt" ]; then
@@ -735,6 +746,13 @@ done
 
 b2sums=('1e8e226364a85f3fd66e51495a99a76e377389aa48c708953aaa28b6ec669f05aab6d240365965eec5643e2fa6aee15796005b2873e8fea748e432b1d799eabc'
         '9661bd2574e911f4fe3f365d849fb9d3ea2bc0ceaa13015aaa7e266ef105c7e1617acf375e72f72bb95f9a4589c6779bf03f833df66ed1cca3b9f6662e0ee5c8'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
         '39b60319ce157ad58d655c220d34ede65275ec5638e5fad4602d89aa9a93aaa17e2c2f00c0c978aa2b42056f5ea04e3319b44484cd8eeda16637c6cd0ed9c5d4'
         'be844475f453f79f5d892c2cc2a6843b32501e2a7c57dd0859ec0cba2262d9fa9a95fff77b6e3718dff449c0f3b428fce03bc35d8332081427feedd461388498'
         'b6687df66d03a4ae56e32b119f93df7d8133faa3da0d5ca54c9a9da53e39b60d8f3c24c0d6b2d716366b555613b081c6fbd74ad6cc6d9ef692a9991236c6884f'

--- a/linux-cachyos-eevdf/PKGBUILD
+++ b/linux-cachyos-eevdf/PKGBUILD
@@ -180,6 +180,13 @@ _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(
     "https://cdn.kernel.org/pub/linux/kernel/v${pkgver%%.*}.x/${_srcname}.tar.xz"
     "config"
+    "${_patchsource}/isp4/0001-amd-isp4.patch"
+    "${_patchsource}/isp4/0002-amd-isp4.patch"
+    "${_patchsource}/isp4/0003-amd-isp4.patch"
+    "${_patchsource}/isp4/0004-amd-isp4.patch"
+    "${_patchsource}/isp4/0005-amd-isp4.patch"
+    "${_patchsource}/isp4/0006-amd-isp4.patch"
+    "${_patchsource}/isp4/0007-amd-isp4.patch"
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
@@ -257,6 +264,10 @@ prepare() {
 
     echo "Setting config..."
     cp ../config .config
+
+    ### Enable AMD ISP4 Driver
+    echo "Enabling AMD ISP4 Driver..."
+    scripts/config -m AMD_ISP4
 
     ### Select CPU optimization
     if [ -n "$_processor_opt" ]; then
@@ -731,4 +742,11 @@ done
 
 b2sums=('1e8e226364a85f3fd66e51495a99a76e377389aa48c708953aaa28b6ec669f05aab6d240365965eec5643e2fa6aee15796005b2873e8fea748e432b1d799eabc'
         'bc863600b02ccb6404e95e85f31b1cbc1293c663e0dd96eb0b7f42277b937849f156f509e688862d6926711e2297712bce4fdbfc04231b104b2608b1fc1ba34b'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
         '39b60319ce157ad58d655c220d34ede65275ec5638e5fad4602d89aa9a93aaa17e2c2f00c0c978aa2b42056f5ea04e3319b44484cd8eeda16637c6cd0ed9c5d4')

--- a/linux-cachyos-hardened/PKGBUILD
+++ b/linux-cachyos-hardened/PKGBUILD
@@ -180,6 +180,13 @@ _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(
     "https://cdn.kernel.org/pub/linux/kernel/v${pkgver%%.*}.x/${_srcname}.tar.xz"
     "config"
+    "${_patchsource}/isp4/0001-amd-isp4.patch"
+    "${_patchsource}/isp4/0002-amd-isp4.patch"
+    "${_patchsource}/isp4/0003-amd-isp4.patch"
+    "${_patchsource}/isp4/0004-amd-isp4.patch"
+    "${_patchsource}/isp4/0005-amd-isp4.patch"
+    "${_patchsource}/isp4/0006-amd-isp4.patch"
+    "${_patchsource}/isp4/0007-amd-isp4.patch"
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
@@ -257,6 +264,10 @@ prepare() {
 
     echo "Setting config..."
     cp ../config .config
+
+    ### Enable AMD ISP4 Driver
+    echo "Enabling AMD ISP4 Driver..."
+    scripts/config -m AMD_ISP4
 
     ### Select CPU optimization
     if [ -n "$_processor_opt" ]; then
@@ -730,6 +741,13 @@ done
 
 b2sums=('1e8e226364a85f3fd66e51495a99a76e377389aa48c708953aaa28b6ec669f05aab6d240365965eec5643e2fa6aee15796005b2873e8fea748e432b1d799eabc'
         '93e0bd13bbf3791c94f92da102039dbca8c4e53f55f2cc2e9d1b4f75bcdf2d9472350be25e5b4ddfed987f78b18c2e77195657552441410f34bd00387beb5097'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
         '39b60319ce157ad58d655c220d34ede65275ec5638e5fad4602d89aa9a93aaa17e2c2f00c0c978aa2b42056f5ea04e3319b44484cd8eeda16637c6cd0ed9c5d4'
         '966b8059310169dd0806bfad95d01b8587258113962064e3f0d7ee429bc010e62aaf201666a0c6ab7feb5f50b5aabe08b9e99cbac033c29140799bc5cb6178be'
         '21c0b8c538d602a3bf4ef2e0ff8538430522b2cb11fc3bc42ee20c99d23c44a8921cece50a3147e6993c0be325883fd0e4e309e0ba31ca95d5244b28510b59c8')

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -206,6 +206,13 @@ _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(
     "https://github.com/torvalds/linux/archive/refs/tags/v${_major}-${_rcver}.tar.gz"
     "config"
+    "${_patchsource}/isp4/0001-amd-isp4.patch"
+    "${_patchsource}/isp4/0002-amd-isp4.patch"
+    "${_patchsource}/isp4/0003-amd-isp4.patch"
+    "${_patchsource}/isp4/0004-amd-isp4.patch"
+    "${_patchsource}/isp4/0005-amd-isp4.patch"
+    "${_patchsource}/isp4/0006-amd-isp4.patch"
+    "${_patchsource}/isp4/0007-amd-isp4.patch"
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
@@ -299,6 +306,10 @@ prepare() {
 
     echo "Setting config..."
     cp ../config .config
+
+    ### Enable AMD ISP4 Driver
+    echo "Enabling AMD ISP4 Driver..."
+    scripts/config -m AMD_ISP4
 
     ### Select CPU optimization
     if [ -n "$_processor_opt" ]; then
@@ -799,5 +810,12 @@ done
 
 b2sums=('6b17389bf23dc88f21cec0c7727427882cdb5df87d34c60d839f620b6fc05e449d584fbd03c8623f080d07203d6e475a8d6b4ef11c8cde9bd1ca18d013063cad'
         'b8383d11c153967b13a58f36981c8c6041ba1ec24651f5472f2dddede8da6ebe0516d718b37440bd38a46c2e50cde295d82103d1e88d23b6fdbdf1f01c1bda48'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
         'd14fe243ba5b5349c4f51fe36c5d986ba176f96c99ffa1f3ad4f9c879ffbc2e6ae038214333010accef5434b4ffee3549f37cda4eb84c962196891de6afad6db'
         'ace0a9f6e0b204ee2a013fd9d4cae4b4d6a3f2fd8aea890788ff46102ca4c54396ec05b5c2375b743c257ae56a2db40d8fdcc0cc9f24c3f168ee28368fe81042')

--- a/linux-cachyos-rt-bore/PKGBUILD
+++ b/linux-cachyos-rt-bore/PKGBUILD
@@ -180,6 +180,13 @@ _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(
     "https://cdn.kernel.org/pub/linux/kernel/v${pkgver%%.*}.x/${_srcname}.tar.xz"
     "config"
+    "${_patchsource}/isp4/0001-amd-isp4.patch"
+    "${_patchsource}/isp4/0002-amd-isp4.patch"
+    "${_patchsource}/isp4/0003-amd-isp4.patch"
+    "${_patchsource}/isp4/0004-amd-isp4.patch"
+    "${_patchsource}/isp4/0005-amd-isp4.patch"
+    "${_patchsource}/isp4/0006-amd-isp4.patch"
+    "${_patchsource}/isp4/0007-amd-isp4.patch"
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
@@ -257,6 +264,10 @@ prepare() {
 
     echo "Setting config..."
     cp ../config .config
+
+    ### Enable AMD ISP4 Driver
+    echo "Enabling AMD ISP4 Driver..."
+    scripts/config -m AMD_ISP4
 
     ### Select CPU optimization
     if [ -n "$_processor_opt" ]; then
@@ -731,6 +742,13 @@ done
 
 b2sums=('1e8e226364a85f3fd66e51495a99a76e377389aa48c708953aaa28b6ec669f05aab6d240365965eec5643e2fa6aee15796005b2873e8fea748e432b1d799eabc'
         'bc863600b02ccb6404e95e85f31b1cbc1293c663e0dd96eb0b7f42277b937849f156f509e688862d6926711e2297712bce4fdbfc04231b104b2608b1fc1ba34b'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
         '39b60319ce157ad58d655c220d34ede65275ec5638e5fad4602d89aa9a93aaa17e2c2f00c0c978aa2b42056f5ea04e3319b44484cd8eeda16637c6cd0ed9c5d4'
         '966b8059310169dd0806bfad95d01b8587258113962064e3f0d7ee429bc010e62aaf201666a0c6ab7feb5f50b5aabe08b9e99cbac033c29140799bc5cb6178be'
         '993581243d5eeb7c412a60beca396524201d7274ea01145df25b2742a4c50f677695730be298d32d523ff56314621b735d5d8616a5f2f61e796a05670a877983')

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -205,6 +205,13 @@ _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(
     "https://cdn.kernel.org/pub/linux/kernel/v${pkgver%%.*}.x/${_srcname}.tar.xz"
     "config"
+    "${_patchsource}/isp4/0001-amd-isp4.patch"
+    "${_patchsource}/isp4/0002-amd-isp4.patch"
+    "${_patchsource}/isp4/0003-amd-isp4.patch"
+    "${_patchsource}/isp4/0004-amd-isp4.patch"
+    "${_patchsource}/isp4/0005-amd-isp4.patch"
+    "${_patchsource}/isp4/0006-amd-isp4.patch"
+    "${_patchsource}/isp4/0007-amd-isp4.patch"
     "${_patchsource}/all/0001-cachyos-base-all.patch")
 
 # LLVM makedepends
@@ -297,6 +304,10 @@ prepare() {
 
     echo "Setting config..."
     cp ../config .config
+
+    ### Enable AMD ISP4 Driver
+    echo "Enabling AMD ISP4 Driver..."
+    scripts/config -m AMD_ISP4
 
     ### Select CPU optimization
     if [ -n "$_processor_opt" ]; then
@@ -803,5 +814,12 @@ done
 
 b2sums=('1e8e226364a85f3fd66e51495a99a76e377389aa48c708953aaa28b6ec669f05aab6d240365965eec5643e2fa6aee15796005b2873e8fea748e432b1d799eabc'
         'bc863600b02ccb6404e95e85f31b1cbc1293c663e0dd96eb0b7f42277b937849f156f509e688862d6926711e2297712bce4fdbfc04231b104b2608b1fc1ba34b'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
+        'SKIP'
         '39b60319ce157ad58d655c220d34ede65275ec5638e5fad4602d89aa9a93aaa17e2c2f00c0c978aa2b42056f5ea04e3319b44484cd8eeda16637c6cd0ed9c5d4'
         'c7294a689f70b2a44b0c4e9f00c61dbd59dd7063ecbe18655c4e7f12e21ed7c5bb4f5169f5aa8623b1c59de7b2667facb024913ecb9f4c650dabce4e8a7e5452')


### PR DESCRIPTION
https://www.phoronix.com/news/AMD-ISP4-Driver-v6

This PR adds patches for AMD ISP4 Linux Webcam Driver for HP ZBook Ultra G1a & Future Ryzen Laptops.

Requires https://github.com/CachyOS/kernel-patches/pull/123