### PR TITLE
linux-cachyos-rc: Add missed function

### DIFF
--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -156,6 +156,11 @@ _is_lto_kernel() {
     return $?
 }
 
+_is_ci_build() {
+    [[ -n "$CI" || -n "$GITHUB_RUN_ID" ]]
+    return $?
+}
+
 if _is_lto_kernel && [ "$_use_lto_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-rc-lto"
 elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then


### PR DESCRIPTION
Fixes: 3e2055c70d7e8d61696b13031597ed7cd8c7a1ee