### PR TITLE
r8125: use pkgname-based modprobe.d filename to avoid conflicts

### DIFF
--- a/linux-cachyos-bmq/PKGBUILD
+++ b/linux-cachyos-bmq/PKGBUILD
@@ -720,7 +720,7 @@ _package-r8125() {
 
     # Blacklist r8169 so that r8125 is used instead
     install -dm755 "${pkgdir}/usr/lib/modprobe.d"
-    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/r8125.conf"
+    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/${pkgname}.conf"
 }
 
 pkgname=("$pkgbase")

--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -720,7 +720,7 @@ _package-r8125() {
 
     # Blacklist r8169 so that r8125 is used instead
     install -dm755 "${pkgdir}/usr/lib/modprobe.d"
-    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/r8125.conf"
+    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/${pkgname}.conf"
 }
 
 pkgname=("$pkgbase")

--- a/linux-cachyos-deckify/PKGBUILD
+++ b/linux-cachyos-deckify/PKGBUILD
@@ -724,7 +724,7 @@ _package-r8125() {
 
     # Blacklist r8169 so that r8125 is used instead
     install -dm755 "${pkgdir}/usr/lib/modprobe.d"
-    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/r8125.conf"
+    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/${pkgname}.conf"
 }
 
 pkgname=("$pkgbase")

--- a/linux-cachyos-eevdf/PKGBUILD
+++ b/linux-cachyos-eevdf/PKGBUILD
@@ -720,7 +720,7 @@ _package-r8125() {
 
     # Blacklist r8169 so that r8125 is used instead
     install -dm755 "${pkgdir}/usr/lib/modprobe.d"
-    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/r8125.conf"
+    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/${pkgname}.conf"
 }
 
 pkgname=("$pkgbase")

--- a/linux-cachyos-hardened/PKGBUILD
+++ b/linux-cachyos-hardened/PKGBUILD
@@ -709,7 +709,7 @@ _package-r8125() {
 
     # Blacklist r8169 so that r8125 is used instead
     install -dm755 "${pkgdir}/usr/lib/modprobe.d"
-    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/r8125.conf"
+    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/${pkgname}.conf"
 }
 
 pkgname=("$pkgbase")

--- a/linux-cachyos-lts/PKGBUILD
+++ b/linux-cachyos-lts/PKGBUILD
@@ -718,7 +718,7 @@ _package-r8125() {
 
     # Blacklist r8169 so that r8125 is used instead
     install -dm755 "${pkgdir}/usr/lib/modprobe.d"
-    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/r8125.conf"
+    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/${pkgname}.conf"
 }
 
 pkgname=("$pkgbase")

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -785,7 +785,7 @@ _package-r8125() {
 
     # Blacklist r8169 so that r8125 is used instead
     install -dm755 "${pkgdir}/usr/lib/modprobe.d"
-    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/r8125.conf"
+    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/${pkgname}.conf"
 }
 
 pkgname=("$pkgbase")

--- a/linux-cachyos-rt-bore/PKGBUILD
+++ b/linux-cachyos-rt-bore/PKGBUILD
@@ -720,7 +720,7 @@ _package-r8125() {
 
     # Blacklist r8169 so that r8125 is used instead
     install -dm755 "${pkgdir}/usr/lib/modprobe.d"
-    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/r8125.conf"
+    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/${pkgname}.conf"
 }
 
 pkgname=("$pkgbase")

--- a/linux-cachyos-server/PKGBUILD
+++ b/linux-cachyos-server/PKGBUILD
@@ -720,7 +720,7 @@ _package-r8125() {
 
     # Blacklist r8169 so that r8125 is used instead
     install -dm755 "${pkgdir}/usr/lib/modprobe.d"
-    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/r8125.conf"
+    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/${pkgname}.conf"
 }
 
 pkgname=("$pkgbase")

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -792,7 +792,7 @@ _package-r8125() {
 
     # Blacklist r8169 so that r8125 is used instead
     install -dm755 "${pkgdir}/usr/lib/modprobe.d"
-    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/r8125.conf"
+    echo "blacklist r8169" > "${pkgdir}/usr/lib/modprobe.d/${pkgname}.conf"
 }
 
 pkgname=("$pkgbase")


### PR DESCRIPTION
Avoid conflicts on multiple kernels