### PR TITLE
PKGBUILD: add "clang" mode and rename _use_llvm_lto to _use_llvm

### DIFF
--- a/linux-cachyos-bmq/PKGBUILD
+++ b/linux-cachyos-bmq/PKGBUILD
@@ -478,7 +478,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm" != "none" ]; then
+    if _is_clang_build; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -514,7 +514,9 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        if _is_clang_build; then
+            CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        fi
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure

--- a/linux-cachyos-bmq/PKGBUILD
+++ b/linux-cachyos-bmq/PKGBUILD
@@ -86,13 +86,14 @@
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 : "${_processor_opt:=}"
 
-# Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
-# ATTENTION - one of three predefined values should be selected!
-# "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
-# "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
-# "thin-dist: Similar to thin, but uses a distributed model rather than in-process: https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934"
-# "none: disable LTO
-: "${_use_llvm_lto:=none}"
+# Compiler and LTO selection - options are "none", "clang", "thin", "thin-dist" or "full".
+# ATTENTION - one of the predefined values should be selected!
+# "none": use GCC with LTO disabled.
+# "clang": use Clang as compiler but with LTO disabled.
+# "thin": use Clang with ThinLTO - multiple threads, faster and uses less memory, may have a lower runtime performance than Full.
+# "thin-dist": use Clang with distributed ThinLTO - https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934
+# "full": use Clang with Full LTO - 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains.
+: "${_use_llvm:=none}"
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
@@ -131,7 +132,12 @@
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full"  || "$_use_llvm_lto" = "thin-dist" ]]
+    [[ "$_use_llvm" = "thin" || "$_use_llvm" = "full"  || "$_use_llvm" = "thin-dist" ]]
+    return $?
+}
+
+_is_clang_build() {
+    _is_lto_kernel || [[ "$_use_llvm" = "clang" ]]
     return $?
 }
 
@@ -142,7 +148,7 @@ _is_ci_build() {
 
 if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix="cachyos-${_cpusched}-lto"
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
+elif ! _is_clang_build && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-${_cpusched}-gcc"
 else
     _pkgsuffix="cachyos-${_cpusched}"
@@ -200,7 +206,7 @@ validpgpkeys=(
 )
 
 # LLVM makedepends
-if _is_lto_kernel; then
+if _is_clang_build; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(
@@ -314,18 +320,18 @@ prepare() {
     fi
 
     ### Select LLVM level
-    case "$_use_llvm_lto" in
+    case "$_use_llvm" in
         thin) scripts/config -e LTO_CLANG_THIN;;
         thin-dist) scripts/config -e LTO_CLANG_THIN_DIST;;
         full) scripts/config -e LTO_CLANG_FULL;;
-        none) scripts/config -e LTO_NONE;;
-        *) _die "The value '$_use_llvm_lto' is invalid. Choose the correct one again.";;
+        clang|none) scripts/config -e LTO_NONE;;
+        *) _die "The value '$_use_llvm' is invalid. Choose the correct one again.";;
     esac
 
-    echo "Selecting '$_use_llvm_lto' LLVM level..."
+    echo "Selecting '$_use_llvm' LLVM level..."
 
     if ! _is_lto_kernel; then
-        echo "Enabling QR Code Panic for GCC Kernels"
+        echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \
             --set-val CONFIG_DRM_PANIC_SCREEN_QR_VERSION 40
@@ -472,7 +478,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm_lto" != "none" ]; then
+    if [ "$_use_llvm" != "none" ]; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -508,7 +514,7 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm_lto" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure
@@ -568,6 +574,10 @@ _package-headers() {
       zstd
      "${pkgbase}")
     provides=(LINUX-HEADERS)
+
+    if _is_clang_build; then
+        depends+=(clang llvm lld)
+    fi
 
     cd "${_srcname}"
     local builddir="$pkgdir/usr/lib/modules/$(<version)/build"

--- a/linux-cachyos-bmq/PKGBUILD
+++ b/linux-cachyos-bmq/PKGBUILD
@@ -330,7 +330,7 @@ prepare() {
 
     echo "Selecting '$_use_llvm' LLVM level..."
 
-    if ! _is_lto_kernel; then
+    if [[ "$_use_llvm" = "none" || "$_use_llvm" = "clang" ]]; then
         echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \

--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -478,7 +478,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm" != "none" ]; then
+    if _is_clang_build; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -514,7 +514,9 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        if _is_clang_build; then
+            CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        fi
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure

--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -86,13 +86,14 @@
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 : "${_processor_opt:=}"
 
-# Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
-# ATTENTION - one of three predefined values should be selected!
-# "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
-# "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
-# "thin-dist: Similar to thin, but uses a distributed model rather than in-process: https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934"
-# "none: disable LTO
-: "${_use_llvm_lto:=none}"
+# Compiler and LTO selection - options are "none", "clang", "thin", "thin-dist" or "full".
+# ATTENTION - one of the predefined values should be selected!
+# "none": use GCC with LTO disabled.
+# "clang": use Clang as compiler but with LTO disabled.
+# "thin": use Clang with ThinLTO - multiple threads, faster and uses less memory, may have a lower runtime performance than Full.
+# "thin-dist": use Clang with distributed ThinLTO - https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934
+# "full": use Clang with Full LTO - 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains.
+: "${_use_llvm:=none}"
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
@@ -131,7 +132,12 @@
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full"  || "$_use_llvm_lto" = "thin-dist" ]]
+    [[ "$_use_llvm" = "thin" || "$_use_llvm" = "full"  || "$_use_llvm" = "thin-dist" ]]
+    return $?
+}
+
+_is_clang_build() {
+    _is_lto_kernel || [[ "$_use_llvm" = "clang" ]]
     return $?
 }
 
@@ -142,7 +148,7 @@ _is_ci_build() {
 
 if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix="cachyos-${_cpusched}-lto"
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
+elif ! _is_clang_build && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-${_cpusched}-gcc"
 else
     _pkgsuffix="cachyos-${_cpusched}"
@@ -200,7 +206,7 @@ validpgpkeys=(
 )
 
 # LLVM makedepends
-if _is_lto_kernel; then
+if _is_clang_build; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(
@@ -314,18 +320,18 @@ prepare() {
     fi
 
     ### Select LLVM level
-    case "$_use_llvm_lto" in
+    case "$_use_llvm" in
         thin) scripts/config -e LTO_CLANG_THIN;;
         thin-dist) scripts/config -e LTO_CLANG_THIN_DIST;;
         full) scripts/config -e LTO_CLANG_FULL;;
-        none) scripts/config -e LTO_NONE;;
-        *) _die "The value '$_use_llvm_lto' is invalid. Choose the correct one again.";;
+        clang|none) scripts/config -e LTO_NONE;;
+        *) _die "The value '$_use_llvm' is invalid. Choose the correct one again.";;
     esac
 
-    echo "Selecting '$_use_llvm_lto' LLVM level..."
+    echo "Selecting '$_use_llvm' LLVM level..."
 
     if ! _is_lto_kernel; then
-        echo "Enabling QR Code Panic for GCC Kernels"
+        echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \
             --set-val CONFIG_DRM_PANIC_SCREEN_QR_VERSION 40
@@ -472,7 +478,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm_lto" != "none" ]; then
+    if [ "$_use_llvm" != "none" ]; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -508,7 +514,7 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm_lto" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure
@@ -568,6 +574,10 @@ _package-headers() {
       zstd
      "${pkgbase}")
     provides=(LINUX-HEADERS)
+
+    if _is_clang_build; then
+        depends+=(clang llvm lld)
+    fi
 
     cd "${_srcname}"
     local builddir="$pkgdir/usr/lib/modules/$(<version)/build"

--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -330,7 +330,7 @@ prepare() {
 
     echo "Selecting '$_use_llvm' LLVM level..."
 
-    if ! _is_lto_kernel; then
+    if [[ "$_use_llvm" = "none" || "$_use_llvm" = "clang" ]]; then
         echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \

--- a/linux-cachyos-deckify/PKGBUILD
+++ b/linux-cachyos-deckify/PKGBUILD
@@ -497,7 +497,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm" != "none" ]; then
+    if _is_clang_build; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -533,7 +533,9 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        if _is_clang_build; then
+            CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        fi
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure

--- a/linux-cachyos-deckify/PKGBUILD
+++ b/linux-cachyos-deckify/PKGBUILD
@@ -86,13 +86,14 @@
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 : "${_processor_opt:=}"
 
-# Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
-# ATTENTION - one of three predefined values should be selected!
-# "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
-# "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
-# "thin-dist: Similar to thin, but uses a distributed model rather than in-process: https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934"
-# "none: disable LTO
-: "${_use_llvm_lto:=none}"
+# Compiler and LTO selection - options are "none", "clang", "thin", "thin-dist" or "full".
+# ATTENTION - one of the predefined values should be selected!
+# "none": use GCC with LTO disabled.
+# "clang": use Clang as compiler but with LTO disabled.
+# "thin": use Clang with ThinLTO - multiple threads, faster and uses less memory, may have a lower runtime performance than Full.
+# "thin-dist": use Clang with distributed ThinLTO - https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934
+# "full": use Clang with Full LTO - 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains.
+: "${_use_llvm:=none}"
 
 # Use suffix -lto only when requested by the user
 # yes - enable -lto suffix
@@ -130,7 +131,12 @@
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full"  || "$_use_llvm_lto" = "thin-dist" ]]
+    [[ "$_use_llvm" = "thin" || "$_use_llvm" = "full"  || "$_use_llvm" = "thin-dist" ]]
+    return $?
+}
+
+_is_clang_build() {
+    _is_lto_kernel || [[ "$_use_llvm" = "clang" ]]
     return $?
 }
 
@@ -141,7 +147,7 @@ _is_ci_build() {
 
 if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix="cachyos-deckify-lto"
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
+elif ! _is_clang_build && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-deckify-gcc"
 else
     _pkgsuffix="cachyos-deckify"
@@ -200,7 +206,7 @@ validpgpkeys=(
 )
 
 # LLVM makedepends
-if _is_lto_kernel; then
+if _is_clang_build; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(
@@ -314,18 +320,18 @@ prepare() {
     fi
 
     ### Select LLVM level
-    case "$_use_llvm_lto" in
+    case "$_use_llvm" in
         thin) scripts/config -e LTO_CLANG_THIN;;
         thin-dist) scripts/config -e LTO_CLANG_THIN_DIST;;
         full) scripts/config -e LTO_CLANG_FULL;;
-        none) scripts/config -e LTO_NONE;;
-        *) _die "The value '$_use_llvm_lto' is invalid. Choose the correct one again.";;
+        clang|none) scripts/config -e LTO_NONE;;
+        *) _die "The value '$_use_llvm' is invalid. Choose the correct one again.";;
     esac
 
-    echo "Selecting '$_use_llvm_lto' LLVM level..."
+    echo "Selecting '$_use_llvm' LLVM level..."
 
     if ! _is_lto_kernel; then
-        echo "Enabling QR Code Panic for GCC Kernels"
+        echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \
             --set-val CONFIG_DRM_PANIC_SCREEN_QR_VERSION 40
@@ -491,7 +497,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm_lto" != "none" ]; then
+    if [ "$_use_llvm" != "none" ]; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -527,7 +533,7 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm_lto" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure
@@ -587,6 +593,10 @@ _package-headers() {
       zstd
      "${pkgbase}")
     provides=(LINUX-HEADERS)
+
+    if _is_clang_build; then
+        depends+=(clang llvm lld)
+    fi
 
     cd "${_srcname}"
     local builddir="$pkgdir/usr/lib/modules/$(<version)/build"

--- a/linux-cachyos-deckify/PKGBUILD
+++ b/linux-cachyos-deckify/PKGBUILD
@@ -330,7 +330,7 @@ prepare() {
 
     echo "Selecting '$_use_llvm' LLVM level..."
 
-    if ! _is_lto_kernel; then
+    if [[ "$_use_llvm" = "none" || "$_use_llvm" = "clang" ]]; then
         echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \

--- a/linux-cachyos-eevdf/PKGBUILD
+++ b/linux-cachyos-eevdf/PKGBUILD
@@ -86,13 +86,14 @@
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 : "${_processor_opt:=}"
 
-# Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
-# ATTENTION - one of three predefined values should be selected!
-# "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
-# "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
-# "thin-dist: Similar to thin, but uses a distributed model rather than in-process: https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934"
-# "none: disable LTO
-: "${_use_llvm_lto:=none}"
+# Compiler and LTO selection - options are "none", "clang", "thin", "thin-dist" or "full".
+# ATTENTION - one of the predefined values should be selected!
+# "none": use GCC with LTO disabled.
+# "clang": use Clang as compiler but with LTO disabled.
+# "thin": use Clang with ThinLTO - multiple threads, faster and uses less memory, may have a lower runtime performance than Full.
+# "thin-dist": use Clang with distributed ThinLTO - https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934
+# "full": use Clang with Full LTO - 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains.
+: "${_use_llvm:=none}"
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
@@ -131,7 +132,12 @@
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full"  || "$_use_llvm_lto" = "thin-dist" ]]
+    [[ "$_use_llvm" = "thin" || "$_use_llvm" = "full"  || "$_use_llvm" = "thin-dist" ]]
+    return $?
+}
+
+_is_clang_build() {
+    _is_lto_kernel || [[ "$_use_llvm" = "clang" ]]
     return $?
 }
 
@@ -142,7 +148,7 @@ _is_ci_build() {
 
 if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix="cachyos-${_cpusched}-lto"
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
+elif ! _is_clang_build && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-${_cpusched}-gcc"
 else
     _pkgsuffix="cachyos-${_cpusched}"
@@ -203,7 +209,7 @@ validpgpkeys=(
 )
 
 # LLVM makedepends
-if _is_lto_kernel; then
+if _is_clang_build; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(
@@ -317,18 +323,18 @@ prepare() {
     fi
 
     ### Select LLVM level
-    case "$_use_llvm_lto" in
+    case "$_use_llvm" in
         thin) scripts/config -e LTO_CLANG_THIN;;
         thin-dist) scripts/config -e LTO_CLANG_THIN_DIST;;
         full) scripts/config -e LTO_CLANG_FULL;;
-        none) scripts/config -e LTO_NONE;;
-        *) _die "The value '$_use_llvm_lto' is invalid. Choose the correct one again.";;
+        clang|none) scripts/config -e LTO_NONE;;
+        *) _die "The value '$_use_llvm' is invalid. Choose the correct one again.";;
     esac
 
-    echo "Selecting '$_use_llvm_lto' LLVM level..."
+    echo "Selecting '$_use_llvm' LLVM level..."
 
     if ! _is_lto_kernel; then
-        echo "Enabling QR Code Panic for GCC Kernels"
+        echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \
             --set-val CONFIG_DRM_PANIC_SCREEN_QR_VERSION 40
@@ -475,7 +481,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm_lto" != "none" ]; then
+    if [ "$_use_llvm" != "none" ]; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -511,7 +517,7 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm_lto" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure
@@ -571,6 +577,10 @@ _package-headers() {
       zstd
      "${pkgbase}")
     provides=(LINUX-HEADERS)
+
+    if _is_clang_build; then
+        depends+=(clang llvm lld)
+    fi
 
     cd "${_srcname}"
     local builddir="$pkgdir/usr/lib/modules/$(<version)/build"

--- a/linux-cachyos-eevdf/PKGBUILD
+++ b/linux-cachyos-eevdf/PKGBUILD
@@ -333,7 +333,7 @@ prepare() {
 
     echo "Selecting '$_use_llvm' LLVM level..."
 
-    if ! _is_lto_kernel; then
+    if [[ "$_use_llvm" = "none" || "$_use_llvm" = "clang" ]]; then
         echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \

--- a/linux-cachyos-eevdf/PKGBUILD
+++ b/linux-cachyos-eevdf/PKGBUILD
@@ -481,7 +481,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm" != "none" ]; then
+    if _is_clang_build; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -517,7 +517,9 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        if _is_clang_build; then
+            CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        fi
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure

--- a/linux-cachyos-hardened/PKGBUILD
+++ b/linux-cachyos-hardened/PKGBUILD
@@ -86,13 +86,14 @@
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 : "${_processor_opt:=}"
 
-# Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
-# ATTENTION - one of three predefined values should be selected!
-# "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
-# "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
-# "thin-dist: Similar to thin, but uses a distributed model rather than in-process: https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934"
-# "none: disable LTO
-: "${_use_llvm_lto:=none}"
+# Compiler and LTO selection - options are "none", "clang", "thin", "thin-dist" or "full".
+# ATTENTION - one of the predefined values should be selected!
+# "none": use GCC with LTO disabled.
+# "clang": use Clang as compiler but with LTO disabled.
+# "thin": use Clang with ThinLTO - multiple threads, faster and uses less memory, may have a lower runtime performance than Full.
+# "thin-dist": use Clang with distributed ThinLTO - https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934
+# "full": use Clang with Full LTO - 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains.
+: "${_use_llvm:=none}"
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
@@ -131,7 +132,12 @@
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full"  || "$_use_llvm_lto" = "thin-dist" ]]
+    [[ "$_use_llvm" = "thin" || "$_use_llvm" = "full"  || "$_use_llvm" = "thin-dist" ]]
+    return $?
+}
+
+_is_clang_build() {
+    _is_lto_kernel || [[ "$_use_llvm" = "clang" ]]
     return $?
 }
 
@@ -142,7 +148,7 @@ _is_ci_build() {
 
 if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix="cachyos-${_cpusched}-lto"
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
+elif ! _is_clang_build && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-${_cpusched}-gcc"
 else
     _pkgsuffix="cachyos-${_cpusched}"
@@ -200,7 +206,7 @@ validpgpkeys=(
 )
 
 # LLVM makedepends
-if _is_lto_kernel; then
+if _is_clang_build; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(
@@ -314,18 +320,18 @@ prepare() {
     fi
 
     ### Select LLVM level
-    case "$_use_llvm_lto" in
+    case "$_use_llvm" in
         thin) scripts/config -e LTO_CLANG_THIN;;
         thin-dist) scripts/config -e LTO_CLANG_THIN_DIST;;
         full) scripts/config -e LTO_CLANG_FULL;;
-        none) scripts/config -e LTO_NONE;;
-        *) _die "The value '$_use_llvm_lto' is invalid. Choose the correct one again.";;
+        clang|none) scripts/config -e LTO_NONE;;
+        *) _die "The value '$_use_llvm' is invalid. Choose the correct one again.";;
     esac
 
-    echo "Selecting '$_use_llvm_lto' LLVM level..."
+    echo "Selecting '$_use_llvm' LLVM level..."
 
     if ! _is_lto_kernel; then
-        echo "Enabling QR Code Panic for GCC Kernels"
+        echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \
             --set-val CONFIG_DRM_PANIC_SCREEN_QR_VERSION 40
@@ -475,7 +481,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm_lto" != "none" ]; then
+    if [ "$_use_llvm" != "none" ]; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -508,7 +514,7 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm_lto" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure
@@ -568,6 +574,10 @@ _package-headers() {
       zstd
      "${pkgbase}")
     provides=(LINUX-HEADERS)
+
+    if _is_clang_build; then
+        depends+=(clang llvm lld)
+    fi
 
     cd "${_srcname}"
     local builddir="$pkgdir/usr/lib/modules/$(<version)/build"

--- a/linux-cachyos-hardened/PKGBUILD
+++ b/linux-cachyos-hardened/PKGBUILD
@@ -481,7 +481,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm" != "none" ]; then
+    if _is_clang_build; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -514,7 +514,9 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        if _is_clang_build; then
+            CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        fi
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure

--- a/linux-cachyos-hardened/PKGBUILD
+++ b/linux-cachyos-hardened/PKGBUILD
@@ -330,7 +330,7 @@ prepare() {
 
     echo "Selecting '$_use_llvm' LLVM level..."
 
-    if ! _is_lto_kernel; then
+    if [[ "$_use_llvm" = "none" || "$_use_llvm" = "clang" ]]; then
         echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \

--- a/linux-cachyos-lts/PKGBUILD
+++ b/linux-cachyos-lts/PKGBUILD
@@ -327,7 +327,7 @@ prepare() {
 
     echo "Selecting '$_use_llvm' LLVM level..."
 
-    if ! _is_lto_kernel; then
+    if [[ "$_use_llvm" = "none" || "$_use_llvm" = "clang" ]]; then
         echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \

--- a/linux-cachyos-lts/PKGBUILD
+++ b/linux-cachyos-lts/PKGBUILD
@@ -81,13 +81,14 @@
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 : "${_processor_opt:=}"
 
-# Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
-# ATTENTION - one of three predefined values should be selected!
-# "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
-# "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
-# "thin-dist: Similar to thin, but uses a distributed model rather than in-process: https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934"
-# "none: disable LTO
-: "${_use_llvm_lto:=none}"
+# Compiler and LTO selection - options are "none", "clang", "thin", "thin-dist" or "full".
+# ATTENTION - one of the predefined values should be selected!
+# "none": use GCC with LTO disabled.
+# "clang": use Clang as compiler but with LTO disabled.
+# "thin": use Clang with ThinLTO - multiple threads, faster and uses less memory, may have a lower runtime performance than Full.
+# "thin-dist": use Clang with distributed ThinLTO - https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934
+# "full": use Clang with Full LTO - 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains.
+: "${_use_llvm:=none}"
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
@@ -126,7 +127,12 @@
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full"  || "$_use_llvm_lto" = "thin-dist" ]]
+    [[ "$_use_llvm" = "thin" || "$_use_llvm" = "full"  || "$_use_llvm" = "thin-dist" ]]
+    return $?
+}
+
+_is_clang_build() {
+    _is_lto_kernel || [[ "$_use_llvm" = "clang" ]]
     return $?
 }
 
@@ -137,7 +143,7 @@ _is_ci_build() {
 
 if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix="cachyos-lts-lto"
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
+elif ! _is_clang_build && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-lts-gcc"
 else
     _pkgsuffix="cachyos-lts"
@@ -199,7 +205,7 @@ validpgpkeys=(
 )
 
 # LLVM makedepends
-if _is_lto_kernel; then
+if _is_clang_build; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(
@@ -311,18 +317,18 @@ prepare() {
     fi
 
     ### Select LLVM level
-    case "$_use_llvm_lto" in
+    case "$_use_llvm" in
         thin) scripts/config -e LTO_CLANG_THIN;;
         thin-dist) scripts/config -e LTO_CLANG_THIN_DIST;;
         full) scripts/config -e LTO_CLANG_FULL;;
-        none) scripts/config -e LTO_NONE;;
-        *) _die "The value '$_use_llvm_lto' is invalid. Choose the correct one again.";;
+        clang|none) scripts/config -e LTO_NONE;;
+        *) _die "The value '$_use_llvm' is invalid. Choose the correct one again.";;
     esac
 
-    echo "Selecting '$_use_llvm_lto' LLVM level..."
+    echo "Selecting '$_use_llvm' LLVM level..."
 
     if ! _is_lto_kernel; then
-        echo "Enabling QR Code Panic for GCC Kernels"
+        echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \
             --set-val CONFIG_DRM_PANIC_SCREEN_QR_VERSION 40
@@ -474,7 +480,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm_lto" != "none" ]; then
+    if _is_clang_build; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -510,7 +516,9 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm_lto" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        if _is_clang_build; then
+            CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        fi
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure
@@ -570,6 +578,10 @@ _package-headers() {
       zstd
      "${pkgbase}")
     provides=(LINUX-HEADERS)
+
+    if _is_clang_build; then
+        depends+=(clang llvm lld)
+    fi
 
     cd "${_srcname}"
     local builddir="$pkgdir/usr/lib/modules/$(<version)/build"

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -543,7 +543,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm" != "none" ]; then
+    if _is_clang_build; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -579,7 +579,9 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        if _is_clang_build; then
+            CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        fi
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -374,7 +374,7 @@ prepare() {
 
     echo "Selecting '$_use_llvm' LLVM level..."
 
-    if ! _is_lto_kernel; then
+    if [[ "$_use_llvm" = "none" || "$_use_llvm" = "clang" ]]; then
         echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -86,13 +86,14 @@
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 : "${_processor_opt:=}"
 
-# Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
-# ATTENTION - one of three predefined values should be selected!
-# "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
-# "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
-# "thin-dist: Similar to thin, but uses a distributed model rather than in-process: https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934"
-# "none: disable LTO
-: "${_use_llvm_lto:=thin}"
+# Compiler and LTO selection - options are "none", "clang", "thin", "thin-dist" or "full".
+# ATTENTION - one of the predefined values should be selected!
+# "none": use GCC with LTO disabled.
+# "clang": use Clang as compiler but with LTO disabled.
+# "thin": use Clang with ThinLTO - multiple threads, faster and uses less memory, may have a lower runtime performance than Full.
+# "thin-dist": use Clang with distributed ThinLTO - https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934
+# "full": use Clang with Full LTO - 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains.
+: "${_use_llvm:=thin}"
 
 # Use suffix -lto only when requested by the user
 # yes - enable -lto suffix
@@ -156,7 +157,12 @@
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full"  || "$_use_llvm_lto" = "thin-dist" ]]
+    [[ "$_use_llvm" = "thin" || "$_use_llvm" = "full"  || "$_use_llvm" = "thin-dist" ]]
+    return $?
+}
+
+_is_clang_build() {
+    _is_lto_kernel || [[ "$_use_llvm" = "clang" ]]
     return $?
 }
 
@@ -167,7 +173,7 @@ _is_ci_build() {
 
 if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix="cachyos-rc-lto"
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
+elif ! _is_clang_build && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-rc-gcc"
 else
     _pkgsuffix="cachyos-rc"
@@ -229,7 +235,7 @@ validpgpkeys=(
 )
 
 # LLVM makedepends
-if _is_lto_kernel; then
+if _is_clang_build; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(
@@ -358,18 +364,18 @@ prepare() {
     fi
 
     ### Select LLVM level
-    case "$_use_llvm_lto" in
+    case "$_use_llvm" in
         thin) scripts/config -e LTO_CLANG_THIN;;
         thin-dist) scripts/config -e LTO_CLANG_THIN_DIST;;
         full) scripts/config -e LTO_CLANG_FULL;;
-        none) scripts/config -e LTO_NONE;;
-        *) _die "The value '$_use_llvm_lto' is invalid. Choose the correct one again.";;
+        clang|none) scripts/config -e LTO_NONE;;
+        *) _die "The value '$_use_llvm' is invalid. Choose the correct one again.";;
     esac
 
-    echo "Selecting '$_use_llvm_lto' LLVM level..."
+    echo "Selecting '$_use_llvm' LLVM level..."
 
     if ! _is_lto_kernel; then
-        echo "Enabling QR Code Panic for GCC Kernels"
+        echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \
             --set-val CONFIG_DRM_PANIC_SCREEN_QR_VERSION 40
@@ -537,7 +543,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm_lto" != "none" ]; then
+    if [ "$_use_llvm" != "none" ]; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -573,7 +579,7 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm_lto" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure
@@ -634,7 +640,7 @@ _package-headers() {
      "${pkgbase}")
     provides=(LINUX-HEADERS)
 
-    if _is_lto_kernel; then
+    if _is_clang_build; then
         depends+=(clang llvm lld)
     fi
 

--- a/linux-cachyos-rt-bore/PKGBUILD
+++ b/linux-cachyos-rt-bore/PKGBUILD
@@ -86,13 +86,14 @@
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 : "${_processor_opt:=}"
 
-# Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
-# ATTENTION - one of three predefined values should be selected!
-# "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
-# "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
-# "thin-dist: Similar to thin, but uses a distributed model rather than in-process: https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934"
-# "none: disable LTO
-: "${_use_llvm_lto:=none}"
+# Compiler and LTO selection - options are "none", "clang", "thin", "thin-dist" or "full".
+# ATTENTION - one of the predefined values should be selected!
+# "none": use GCC with LTO disabled.
+# "clang": use Clang as compiler but with LTO disabled.
+# "thin": use Clang with ThinLTO - multiple threads, faster and uses less memory, may have a lower runtime performance than Full.
+# "thin-dist": use Clang with distributed ThinLTO - https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934
+# "full": use Clang with Full LTO - 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains.
+: "${_use_llvm:=none}"
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
@@ -131,7 +132,12 @@
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full"  || "$_use_llvm_lto" = "thin-dist" ]]
+    [[ "$_use_llvm" = "thin" || "$_use_llvm" = "full"  || "$_use_llvm" = "thin-dist" ]]
+    return $?
+}
+
+_is_clang_build() {
+    _is_lto_kernel || [[ "$_use_llvm" = "clang" ]]
     return $?
 }
 
@@ -142,7 +148,7 @@ _is_ci_build() {
 
 if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix="cachyos-${_cpusched}-lto"
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
+elif ! _is_clang_build && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-${_cpusched}-gcc"
 else
     _pkgsuffix="cachyos-${_cpusched}"
@@ -203,7 +209,7 @@ validpgpkeys=(
 )
 
 # LLVM makedepends
-if _is_lto_kernel; then
+if _is_clang_build; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(
@@ -317,18 +323,18 @@ prepare() {
     fi
 
     ### Select LLVM level
-    case "$_use_llvm_lto" in
+    case "$_use_llvm" in
         thin) scripts/config -e LTO_CLANG_THIN;;
         thin-dist) scripts/config -e LTO_CLANG_THIN_DIST;;
         full) scripts/config -e LTO_CLANG_FULL;;
-        none) scripts/config -e LTO_NONE;;
-        *) _die "The value '$_use_llvm_lto' is invalid. Choose the correct one again.";;
+        clang|none) scripts/config -e LTO_NONE;;
+        *) _die "The value '$_use_llvm' is invalid. Choose the correct one again.";;
     esac
 
-    echo "Selecting '$_use_llvm_lto' LLVM level..."
+    echo "Selecting '$_use_llvm' LLVM level..."
 
     if ! _is_lto_kernel; then
-        echo "Enabling QR Code Panic for GCC Kernels"
+        echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \
             --set-val CONFIG_DRM_PANIC_SCREEN_QR_VERSION 40
@@ -475,7 +481,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm_lto" != "none" ]; then
+    if [ "$_use_llvm" != "none" ]; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -511,7 +517,7 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm_lto" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure
@@ -571,6 +577,10 @@ _package-headers() {
       zstd
      "${pkgbase}")
     provides=(LINUX-HEADERS)
+
+    if _is_clang_build; then
+        depends+=(clang llvm lld)
+    fi
 
     cd "${_srcname}"
     local builddir="$pkgdir/usr/lib/modules/$(<version)/build"

--- a/linux-cachyos-rt-bore/PKGBUILD
+++ b/linux-cachyos-rt-bore/PKGBUILD
@@ -333,7 +333,7 @@ prepare() {
 
     echo "Selecting '$_use_llvm' LLVM level..."
 
-    if ! _is_lto_kernel; then
+    if [[ "$_use_llvm" = "none" || "$_use_llvm" = "clang" ]]; then
         echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \

--- a/linux-cachyos-rt-bore/PKGBUILD
+++ b/linux-cachyos-rt-bore/PKGBUILD
@@ -481,7 +481,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm" != "none" ]; then
+    if _is_clang_build; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -517,7 +517,9 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        if _is_clang_build; then
+            CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        fi
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure

--- a/linux-cachyos-server/PKGBUILD
+++ b/linux-cachyos-server/PKGBUILD
@@ -478,7 +478,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm" != "none" ]; then
+    if _is_clang_build; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -514,7 +514,9 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        if _is_clang_build; then
+            CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        fi
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure

--- a/linux-cachyos-server/PKGBUILD
+++ b/linux-cachyos-server/PKGBUILD
@@ -330,7 +330,7 @@ prepare() {
 
     echo "Selecting '$_use_llvm' LLVM level..."
 
-    if ! _is_lto_kernel; then
+    if [[ "$_use_llvm" = "none" || "$_use_llvm" = "clang" ]]; then
         echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \

--- a/linux-cachyos-server/PKGBUILD
+++ b/linux-cachyos-server/PKGBUILD
@@ -86,13 +86,14 @@
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 : "${_processor_opt:=}"
 
-# Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
-# ATTENTION - one of three predefined values should be selected!
-# "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
-# "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
-# "thin-dist: Similar to thin, but uses a distributed model rather than in-process: https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934"
-# "none: disable LTO
-: "${_use_llvm_lto:=none}"
+# Compiler and LTO selection - options are "none", "clang", "thin", "thin-dist" or "full".
+# ATTENTION - one of the predefined values should be selected!
+# "none": use GCC with LTO disabled.
+# "clang": use Clang as compiler but with LTO disabled.
+# "thin": use Clang with ThinLTO - multiple threads, faster and uses less memory, may have a lower runtime performance than Full.
+# "thin-dist": use Clang with distributed ThinLTO - https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934
+# "full": use Clang with Full LTO - 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains.
+: "${_use_llvm:=none}"
 
 # Use suffix -lto only when requested by the user
 # Enabled by default.
@@ -131,7 +132,12 @@
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full"  || "$_use_llvm_lto" = "thin-dist" ]]
+    [[ "$_use_llvm" = "thin" || "$_use_llvm" = "full"  || "$_use_llvm" = "thin-dist" ]]
+    return $?
+}
+
+_is_clang_build() {
+    _is_lto_kernel || [[ "$_use_llvm" = "clang" ]]
     return $?
 }
 
@@ -142,7 +148,7 @@ _is_ci_build() {
 
 if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix="cachyos-server-lto"
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
+elif ! _is_clang_build && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix="cachyos-server-gcc"
 else
     _pkgsuffix="cachyos-server"
@@ -200,7 +206,7 @@ validpgpkeys=(
 )
 
 # LLVM makedepends
-if _is_lto_kernel; then
+if _is_clang_build; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(
@@ -314,18 +320,18 @@ prepare() {
     fi
 
     ### Select LLVM level
-    case "$_use_llvm_lto" in
+    case "$_use_llvm" in
         thin) scripts/config -e LTO_CLANG_THIN;;
         thin-dist) scripts/config -e LTO_CLANG_THIN_DIST;;
         full) scripts/config -e LTO_CLANG_FULL;;
-        none) scripts/config -e LTO_NONE;;
-        *) _die "The value '$_use_llvm_lto' is invalid. Choose the correct one again.";;
+        clang|none) scripts/config -e LTO_NONE;;
+        *) _die "The value '$_use_llvm' is invalid. Choose the correct one again.";;
     esac
 
-    echo "Selecting '$_use_llvm_lto' LLVM level..."
+    echo "Selecting '$_use_llvm' LLVM level..."
 
     if ! _is_lto_kernel; then
-        echo "Enabling QR Code Panic for GCC Kernels"
+        echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \
             --set-val CONFIG_DRM_PANIC_SCREEN_QR_VERSION 40
@@ -472,7 +478,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm_lto" != "none" ]; then
+    if [ "$_use_llvm" != "none" ]; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -508,7 +514,7 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm_lto" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure
@@ -568,6 +574,10 @@ _package-headers() {
       zstd
      "${pkgbase}")
     provides=(LINUX-HEADERS)
+
+    if _is_clang_build; then
+        depends+=(clang llvm lld)
+    fi
 
     cd "${_srcname}"
     local builddir="$pkgdir/usr/lib/modules/$(<version)/build"

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -370,7 +370,7 @@ prepare() {
 
     echo "Selecting '$_use_llvm' LLVM level..."
 
-    if ! _is_lto_kernel; then
+    if [[ "$_use_llvm" = "none" || "$_use_llvm" = "clang" ]]; then
         echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -86,13 +86,14 @@
 # - "generic" (kernel's default - to share the package between machines with different CPU µarch as long as they are x86-64)
 : "${_processor_opt:=}"
 
-# Clang LTO mode, only available with the "llvm" compiler - options are "none", "full" or "thin".
-# ATTENTION - one of three predefined values should be selected!
-# "full: uses 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains."
-# "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
-# "thin-dist: Similar to thin, but uses a distributed model rather than in-process: https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934"
-# "none: disable LTO
-: "${_use_llvm_lto:=thin}"
+# Compiler and LTO selection - options are "none", "clang", "thin", "thin-dist" or "full".
+# ATTENTION - one of the predefined values should be selected!
+# "none": use GCC with LTO disabled.
+# "clang": use Clang as compiler but with LTO disabled.
+# "thin": use Clang with ThinLTO - multiple threads, faster and uses less memory, may have a lower runtime performance than Full.
+# "thin-dist": use Clang with distributed ThinLTO - https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934
+# "full": use Clang with Full LTO - 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains.
+: "${_use_llvm:=thin}"
 
 # Use suffix -lto only when requested by the user
 # yes - enable -lto suffix
@@ -156,7 +157,12 @@
 
 # ATTENTION: Do not modify after this line
 _is_lto_kernel() {
-    [[ "$_use_llvm_lto" = "thin" || "$_use_llvm_lto" = "full"  || "$_use_llvm_lto" = "thin-dist" ]]
+    [[ "$_use_llvm" = "thin" || "$_use_llvm" = "full"  || "$_use_llvm" = "thin-dist" ]]
+    return $?
+}
+
+_is_clang_build() {
+    _is_lto_kernel || [[ "$_use_llvm" = "clang" ]]
     return $?
 }
 
@@ -167,7 +173,7 @@ _is_ci_build() {
 
 if _is_lto_kernel && [ "$_use_lto_suffix" = "yes"  ]; then
     _pkgsuffix=cachyos-lto
-elif ! _is_lto_kernel && [ "$_use_gcc_suffix" = "yes" ]; then
+elif ! _is_clang_build && [ "$_use_gcc_suffix" = "yes" ]; then
     _pkgsuffix=cachyos-gcc
 else
     _pkgsuffix=cachyos
@@ -225,7 +231,7 @@ validpgpkeys=(
 )
 
 # LLVM makedepends
-if _is_lto_kernel; then
+if _is_clang_build; then
     makedepends+=(clang llvm lld)
     source+=("${_patchsource}/misc/dkms-clang.patch")
     BUILD_FLAGS=(
@@ -354,18 +360,18 @@ prepare() {
     fi
 
     ### Select LLVM level
-    case "$_use_llvm_lto" in
+    case "$_use_llvm" in
         thin) scripts/config -e LTO_CLANG_THIN;;
         thin-dist) scripts/config -e LTO_CLANG_THIN_DIST;;
         full) scripts/config -e LTO_CLANG_FULL;;
-        none) scripts/config -e LTO_NONE;;
-        *) _die "The value '$_use_llvm_lto' is invalid. Choose the correct one again.";;
+        clang|none) scripts/config -e LTO_NONE;;
+        *) _die "The value '$_use_llvm' is invalid. Choose the correct one again.";;
     esac
 
-    echo "Selecting '$_use_llvm_lto' LLVM level..."
+    echo "Selecting '$_use_llvm' LLVM level..."
 
     if ! _is_lto_kernel; then
-        echo "Enabling QR Code Panic for GCC Kernels"
+        echo "Enabling QR Code Panic for non-LTO Kernels"
         scripts/config --set-str DRM_PANIC_SCREEN qr_code -e DRM_PANIC_SCREEN_QR_CODE \
             --set-str DRM_PANIC_SCREEN_QR_CODE_URL https://panic.archlinux.org/panic_report# \
             --set-val CONFIG_DRM_PANIC_SCREEN_QR_VERSION 40
@@ -533,7 +539,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm_lto" != "none" ]; then
+    if [ "$_use_llvm" != "none" ]; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -569,7 +575,7 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm_lto" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure
@@ -638,6 +644,8 @@ _package-headers() {
     if _is_lto_kernel; then
         provides+=(linux-cachyos-lto-headers=$_kernver)
         replaces=(linux-cachyos-lto-headers)
+    fi
+    if _is_clang_build; then
         depends+=(clang llvm lld)
     fi
 

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -539,7 +539,7 @@ _sign_modules() {
     local sign_cert="${srcdir}/${_srcname}/certs/signing_key.x509"
     local hash_algo="$(grep -Po 'CONFIG_MODULE_SIG_HASH="\K[^"]*' "${srcdir}/${_srcname}/.config")"
 
-    if [ "$_use_llvm" != "none" ]; then
+    if _is_clang_build; then
         local strip_bin="llvm-strip"
     else
         local strip_bin="strip"
@@ -575,7 +575,9 @@ build() {
         cd ${srcdir}/"zfs"
 
         local CONFIGURE_FLAGS=()
-        [ "$_use_llvm" != "none" ] && CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        if _is_clang_build; then
+            CONFIGURE_FLAGS+=("KERNEL_LLVM=1")
+        fi
 
         ./autogen.sh
         sed -i "s|\$(uname -r)|${_kernuname}|g" configure

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -93,7 +93,7 @@
 # "thin": use Clang with ThinLTO - multiple threads, faster and uses less memory, may have a lower runtime performance than Full.
 # "thin-dist": use Clang with distributed ThinLTO - https://discourse.llvm.org/t/rfc-distributed-thinlto-build-for-kernel/85934
 # "full": use Clang with Full LTO - 1 thread for Linking, slow and uses more memory, theoretically with the highest performance gains.
-: "${_use_llvm:=thin}"
+: "${_use_llvm:=clang}"
 
 # Use suffix -lto only when requested by the user
 # yes - enable -lto suffix

--- a/script-v3-v4.sh
+++ b/script-v3-v4.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+
+set_llvm_level() {
+    local old_level=$1
+    local new_level=$2
+
+    find . -name "PKGBUILD" -exec sed -i \
+        -e "s/_use_llvm:=${old_level}/_use_llvm:=${new_level}/" \
+        -e "s/_use_llvm_lto:=${old_level}/_use_llvm_lto:=${new_level}/" {} +
+}
+
 ## Enable ZFS
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_zfs:=no/_build_zfs:=yes/" {}
 ## Enable Generic v3
@@ -9,7 +19,7 @@ find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia_open:=no/_build_nv
 ## Enable r8125 module
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_r8125:=no/_build_r8125:=yes/" {}
 ## Disable clang-LTO
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_llvm_lto:=thin/_use_llvm_lto:=none/" {}
+set_llvm_level thin none
 
 ## GCC v3 Kernel
 
@@ -25,7 +35,7 @@ do
 done
 
 ## LLVM ThinLTO v3 Kernel
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_llvm_lto:=none/_use_llvm_lto:=thin/" {}
+set_llvm_level none thin
 
 files=$(find . -name "PKGBUILD")
 
@@ -45,7 +55,7 @@ RUST_LOG=trace repo-manage-util -p cachyos-v3 update
 RUST_LOG=trace repo-manage-util -p cachyos-v3 update
 
 ## GCC v4 Kernel
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_llvm_lto:=thin/_use_llvm_lto:=none/" {}
+set_llvm_level thin none
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_processor_opt:=GENERIC_V3/_processor_opt:=GENERIC_V4/" {}
 
 files=$(find . -name "PKGBUILD")
@@ -60,7 +70,7 @@ do
 done
 
 ## LLVM ThinLTO v4 Kernel
-find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_llvm_lto:=none/_use_llvm_lto:=thin/" {}
+set_llvm_level none thin
 
 files=$(find . -name "PKGBUILD")
 

--- a/script-v3-v4.sh
+++ b/script-v3-v4.sh
@@ -5,8 +5,7 @@ set_llvm_level() {
     local new_level=$2
 
     find . -name "PKGBUILD" -exec sed -i \
-        -e "s/_use_llvm:=${old_level}/_use_llvm:=${new_level}/" \
-        -e "s/_use_llvm_lto:=${old_level}/_use_llvm_lto:=${new_level}/" {} +
+        -e "s/_use_llvm:=${old_level}/_use_llvm:=${new_level}/" {} +
 }
 
 ## Enable ZFS

--- a/script-v3-v4.sh
+++ b/script-v3-v4.sh
@@ -17,8 +17,9 @@ find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_auto_optimization:=yes/_use
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_nvidia_open:=no/_build_nvidia_open:=yes/" {}
 ## Enable r8125 module
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_r8125:=no/_build_r8125:=yes/" {}
-## Disable clang-LTO
+## Select GCC without LTO
 set_llvm_level thin none
+set_llvm_level clang none
 
 ## GCC v3 Kernel
 
@@ -33,8 +34,8 @@ do
     cd ..
 done
 
-## LLVM ThinLTO v3 Kernel
-set_llvm_level none thin
+## Clang without LTO v3 Kernel
+set_llvm_level none clang
 
 files=$(find . -name "PKGBUILD")
 
@@ -54,7 +55,7 @@ RUST_LOG=trace repo-manage-util -p cachyos-v3 update
 RUST_LOG=trace repo-manage-util -p cachyos-v3 update
 
 ## GCC v4 Kernel
-set_llvm_level thin none
+set_llvm_level clang none
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_processor_opt:=GENERIC_V3/_processor_opt:=GENERIC_V4/" {}
 
 files=$(find . -name "PKGBUILD")
@@ -68,8 +69,8 @@ do
     cd ..
 done
 
-## LLVM ThinLTO v4 Kernel
-set_llvm_level none thin
+## Clang without LTO v4 Kernel
+set_llvm_level none clang
 
 files=$(find . -name "PKGBUILD")
 


### PR DESCRIPTION
Add a new "clang" option to _use_llvm (formerly _use_llvm_lto) that uses Clang as the compiler with LTO disabled. This is useful for AutoFDO/Propeller profiling workflows and testing without the overhead of LTO linking.


I will run some benchmarks to test the performance between ThinLTO + Propeller and Clang + Propeller. The main benefit we would have here, is that we can enable support for Rust and preparing for the future in case more and more drivers get depending on it.

The QR_CODE Bluescreen is pretty nice and we can also implement an own site for this.
Will enhance to other PKGBUILDs when reviewed