### PR TITLE
nvidia: Update to 595.44.02

### DIFF
--- a/linux-cachyos-bmq/PKGBUILD
+++ b/linux-cachyos-bmq/PKGBUILD
@@ -180,7 +180,7 @@ makedepends=(
 )
 
 _patchsource="https://raw.githubusercontent.com/cachyos/kernel-patches/master/${_major}"
-_nv_ver=595.44.02
+_nv_ver=595.45.04
 _nv_pkg="NVIDIA-Linux-x86_64-${_nv_ver}"
 _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(

--- a/linux-cachyos-bore/PKGBUILD
+++ b/linux-cachyos-bore/PKGBUILD
@@ -180,7 +180,7 @@ makedepends=(
 )
 
 _patchsource="https://raw.githubusercontent.com/cachyos/kernel-patches/master/${_major}"
-_nv_ver=595.44.02
+_nv_ver=595.45.04
 _nv_pkg="NVIDIA-Linux-x86_64-${_nv_ver}"
 _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(

--- a/linux-cachyos-deckify/PKGBUILD
+++ b/linux-cachyos-deckify/PKGBUILD
@@ -179,7 +179,7 @@ makedepends=(
 )
 
 _patchsource="https://raw.githubusercontent.com/cachyos/kernel-patches/master/${_major}"
-_nv_ver=595.44.02
+_nv_ver=595.45.04
 _nv_pkg="NVIDIA-Linux-x86_64-${_nv_ver}"
 _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(

--- a/linux-cachyos-eevdf/PKGBUILD
+++ b/linux-cachyos-eevdf/PKGBUILD
@@ -180,7 +180,7 @@ makedepends=(
 )
 
 _patchsource="https://raw.githubusercontent.com/cachyos/kernel-patches/master/${_major}"
-_nv_ver=595.44.02
+_nv_ver=595.45.04
 _nv_pkg="NVIDIA-Linux-x86_64-${_nv_ver}"
 _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(

--- a/linux-cachyos-hardened/PKGBUILD
+++ b/linux-cachyos-hardened/PKGBUILD
@@ -180,7 +180,7 @@ makedepends=(
 )
 
 _patchsource="https://raw.githubusercontent.com/cachyos/kernel-patches/master/${_major}"
-_nv_ver=595.44.02
+_nv_ver=595.45.04
 _nv_pkg="NVIDIA-Linux-x86_64-${_nv_ver}"
 _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(

--- a/linux-cachyos-lts/PKGBUILD
+++ b/linux-cachyos-lts/PKGBUILD
@@ -180,7 +180,7 @@ makedepends=(
 )
 
 _patchsource="https://raw.githubusercontent.com/cachyos/kernel-patches/master/${_major}"
-_nv_ver=595.44.02
+_nv_ver=595.45.04
 _nv_pkg="NVIDIA-Linux-x86_64-${_nv_ver}"
 _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(

--- a/linux-cachyos-rc/PKGBUILD
+++ b/linux-cachyos-rc/PKGBUILD
@@ -205,7 +205,7 @@ makedepends=(
 )
 
 _patchsource="https://raw.githubusercontent.com/cachyos/kernel-patches/master/${_major}"
-_nv_ver=595.44.02
+_nv_ver=595.45.04
 _nv_pkg="NVIDIA-Linux-x86_64-${_nv_ver}"
 _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(

--- a/linux-cachyos-rt-bore/PKGBUILD
+++ b/linux-cachyos-rt-bore/PKGBUILD
@@ -180,7 +180,7 @@ makedepends=(
 )
 
 _patchsource="https://raw.githubusercontent.com/cachyos/kernel-patches/master/${_major}"
-_nv_ver=595.44.02
+_nv_ver=595.45.04
 _nv_pkg="NVIDIA-Linux-x86_64-${_nv_ver}"
 _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(

--- a/linux-cachyos-server/PKGBUILD
+++ b/linux-cachyos-server/PKGBUILD
@@ -180,7 +180,7 @@ makedepends=(
 )
 
 _patchsource="https://raw.githubusercontent.com/cachyos/kernel-patches/master/${_major}"
-_nv_ver=595.44.02
+_nv_ver=595.45.04
 _nv_pkg="NVIDIA-Linux-x86_64-${_nv_ver}"
 _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(

--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -205,7 +205,7 @@ makedepends=(
 )
 
 _patchsource="https://raw.githubusercontent.com/cachyos/kernel-patches/master/${_major}"
-_nv_ver=595.44.02
+_nv_ver=595.45.04
 _nv_pkg="NVIDIA-Linux-x86_64-${_nv_ver}"
 _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(


### PR DESCRIPTION
We are considering to push the 595 Beta release to the stable repository. I've made a poll in the Discord Thread about the 595 Testing.

Testers reporting with 75% having a "Way better experience then 590", this likely includes the improvements with the sleep behavior, fixes in many games (Monster Hunter Vertex explosion,...) and Wayland HDR improvements.
25% reporting that they have an equal experience as 590.

The Heap vulkan extension wont provide any benefit yet, due not being merged in vkd3d-proton.

Outside of this the new driver also introduces Present_Timing, colorspace_swapchain and HDR_Metadata improving the experience massively.
