### PR TITLE
bug_report: Improve upstream kernel check

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,6 +16,8 @@ body:
           required: true
         - label: I have verified the issue is reproducible with the latest available CachyOS kernel.
           required: true
+        - label: I have tried to reproduce the issue on Arch Linux's `linux` kernel.
+          required: true
 
   - type: dropdown
     id: upstream_check
@@ -23,9 +25,9 @@ body:
       label: Upstream / vanilla kernel check
       description: Have you tested with an unmodified upstream kernel to determine if this is CachyOS-specific?
       options:
+        - I have not tested with a vanilla/upstream kernel
         - I tested with a vanilla/upstream kernel and the issue does NOT reproduce there (CachyOS-specific bug)
         - I tested with a vanilla/upstream kernel and the issue ALSO reproduces there (upstream bug — please report upstream)
-        - I was unable to test with a vanilla/upstream kernel
     validations:
       required: true
 


### PR DESCRIPTION
Oftentimes users seem to ignore the "upstream kernel check" and leave it as the default option (tested on upstream and doesn't reproduce). This is oftentimes not the case, and sends false information to maintainers.

Solve this by doing two things:
1. Move "I have not tested upstream kernel" to the top, making it a default option
2. Add "I have tried to reproduce the issue on upstream kernel" to the preflight checklist. This is more like a captcha, so that maintainers can instantly close an issue if this is ticked but "upstream kernel check" is on "I have not tested upstream kernel".