### PR TITLE
linux-cachyos-lts: fix amdgpu s2idle deadlock on HP EliteBook 845 G7

### DIFF
--- a/linux-cachyos-lts/.SRCINFO
+++ b/linux-cachyos-lts/.SRCINFO
@@ -23,8 +23,12 @@ pkgbase = linux-cachyos-lts
 	options = !lto
 	source = https://github.com/CachyOS/linux/releases/download/cachyos-6.18.21-1/cachyos-6.18.21-1.tar.gz
 	source = config
+	source = 0001-amdgpu-disable-securedisplay-ta-on-hp-elitebook-845-g7.patch
+	source = 0003-amdgpu-disable-s0ix-on-hp-elitebook-845-g7.patch
 	b2sums = 524902b34e87a4093972c52eefb0347935fe43623459694ac6d4d00481d45e301df9d0c8d3b7b709d4e50aa85162221b1361f8414adec2a0b9b7c9c545511057
 	b2sums = 81fafd3adcaf3b690d8d4791693e68c7ae921d103ebfd70e8d0ae15cd05ecde5e6672ae43c3a7875686d883c1f5b82d2c8b37b40aee8dcb0563913f9dd6469b6
+	b2sums = 1b527ff75886f16c880e64e3f3292713495acdfb328c730e4574f9f2aa82aa961b2358eebbaaca3bbf95b66f829d2f0f474e3e2cbb432056d6822e1aae5e3a84
+	b2sums = c1ea99b4cf24bc4b0860c1448374fd4004fe4be1d3428f843cc3f7df415c448e903679d5367068eb4f99fc9fe0e46b490f74c0b63b1d921102f7d06c7938f174
 
 pkgname = linux-cachyos-lts
 	pkgdesc = The Linux BORE + Cachy Sauce Kernel by CachyOS with other patches and improvements - Long Term Service kernel and modules

--- a/linux-cachyos-lts/0001-amdgpu-disable-securedisplay-ta-on-hp-elitebook-845-g7.patch
+++ b/linux-cachyos-lts/0001-amdgpu-disable-securedisplay-ta-on-hp-elitebook-845-g7.patch
@@ -1,0 +1,60 @@
+--- a/drivers/gpu/drm/amd/amdgpu/psp_v12_0.c
++++ b/drivers/gpu/drm/amd/amdgpu/psp_v12_0.c
+@@ -20,6 +20,7 @@
+  * OTHER DEALINGS IN THE SOFTWARE.
+  */
+ 
++#include <linux/dmi.h>
+ #include <linux/firmware.h>
+ #include <linux/module.h>
+ #include "amdgpu.h"
+@@ -42,11 +43,28 @@
+ /* address block */
+ #define smnMP1_FIRMWARE_FLAGS		0x3010024
+ 
++static const struct dmi_system_id psp_v12_0_securedisplay_quirk_table[] = {
++	{
++		.matches = {
++			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "HP"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "HP EliteBook 845 G7"),
++		},
++	},
++	{}
++};
++
++static bool psp_v12_0_securedisplay_quirk_active(struct amdgpu_device *adev)
++{
++	return (adev->apu_flags & AMD_APU_IS_RENOIR) &&
++		dmi_first_match(psp_v12_0_securedisplay_quirk_table);
++}
++
+ static int psp_v12_0_init_microcode(struct psp_context *psp)
+ {
+ 	struct amdgpu_device *adev = psp->adev;
+ 	char ucode_prefix[30];
+ 	int err = 0;
++	bool disable_securedisplay;
+ 	DRM_DEBUG("\n");
+ 
+ 	amdgpu_ucode_ip_version_decode(adev, MP0_HWIP, ucode_prefix, sizeof(ucode_prefix));
+@@ -59,9 +77,15 @@
+ 	if (err)
+ 		return err;
+ 
+-	/* only supported on renoir */
+-	if (!(adev->apu_flags & AMD_APU_IS_RENOIR))
++	/* SECUREDISPLAY is optional and known to break resume on some Renoir laptops. */
++	disable_securedisplay = !(adev->apu_flags & AMD_APU_IS_RENOIR) ||
++		psp_v12_0_securedisplay_quirk_active(adev);
++	if (disable_securedisplay) {
++		if (adev->apu_flags & AMD_APU_IS_RENOIR)
++			dev_info(adev->dev,
++				 "PSP: disabling SECUREDISPLAY TA on HP EliteBook 845 G7\n");
+ 		adev->psp.securedisplay_context.context.bin_desc.size_bytes = 0;
++		adev->psp.hdcp_context.context.bin_desc.size_bytes = 0;
++		adev->psp.dtm_context.context.bin_desc.size_bytes = 0;
++		adev->psp.rap_context.context.bin_desc.size_bytes = 0;
++	}
+ 
+ 	return 0;
+ }

--- a/linux-cachyos-lts/0003-amdgpu-disable-s0ix-on-hp-elitebook-845-g7.patch
+++ b/linux-cachyos-lts/0003-amdgpu-disable-s0ix-on-hp-elitebook-845-g7.patch
@@ -1,0 +1,66 @@
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_acpi.c
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_acpi.c
+@@ -25,6 +25,7 @@
+ #include <linux/pci.h>
+ #include <linux/acpi.h>
+ #include <linux/backlight.h>
++#include <linux/dmi.h>
+ #include <linux/slab.h>
+ #include <linux/xarray.h>
+ #include <linux/power_supply.h>
+@@ -1483,12 +1484,51 @@ void amdgpu_acpi_release(void)
+ 
+ #if IS_ENABLED(CONFIG_SUSPEND)
++
++/*
++ * Some Renoir laptops have broken GPU S0ix - the SoC hardware state machine
++ * deadlocks when the GPU driver performs its own suspend handling alongside
++ * the platform s2idle transition. On these systems we force S3-style full
++ * GPU suspend so all IP blocks are properly shut down before s2idle entry.
++ * The amd_pmc driver still handles the platform-level S0i3 transition.
++ */
++static const struct dmi_system_id amdgpu_s0ix_disable_quirk_table[] = {
++	{
++		.matches = {
++			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "HP"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "HP EliteBook 845 G7"),
++		},
++	},
++	{}
++};
++
+ /**
+  * amdgpu_acpi_is_s3_active
+  *
+  * @adev: amdgpu_device_pointer
+  *
+  * returns true if supported, false if not.
+  */
+ bool amdgpu_acpi_is_s3_active(struct amdgpu_device *adev)
+ {
++	/*
++	 * Force S3-style full GPU suspend on platforms where S0ix handling
++	 * is broken. This ensures all IP blocks are properly shut down
++	 * before the platform enters s2idle, giving SMU a clean state.
++	 */
++	if ((adev->flags & AMD_IS_APU) &&
++	    dmi_first_match(amdgpu_s0ix_disable_quirk_table)) {
++		dev_info_once(adev->dev,
++			      "Forcing S3-style GPU suspend for s2idle due to platform quirk\n");
++		return true;
++	}
++
+ 	return !(adev->flags & AMD_IS_APU) ||
+ 		(pm_suspend_target_state == PM_SUSPEND_MEM);
+ }
+@@ -1510,6 +1550,10 @@ bool amdgpu_acpi_is_s0ix_active(struct amdgpu_device *adev)
+ 	if (!(adev->pm.pp_feature & PP_GFXOFF_MASK))
+ 		return false;
+ 
++	/* Disable amdgpu S0ix on platforms with broken GPU suspend */
++	if (dmi_first_match(amdgpu_s0ix_disable_quirk_table))
++		return false;
++
+ 	/*
+ 	 * If ACPI_FADT_LOW_POWER_S0 is not set in the FADT, it is generally
+ 	 * risky to do any special firmware-related preparations for entering

--- a/linux-cachyos-lts/PKGBUILD
+++ b/linux-cachyos-lts/PKGBUILD
@@ -185,7 +185,9 @@ _nv_pkg="NVIDIA-Linux-x86_64-${_nv_ver}"
 _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(
     "https://github.com/CachyOS/linux/releases/download/${_srctag}/${_srctag}.tar.gz"
-    "config")
+    "config"
+    "0001-amdgpu-disable-securedisplay-ta-on-hp-elitebook-845-g7.patch"
+    "0003-amdgpu-disable-s0ix-on-hp-elitebook-845-g7.patch")
 
 # LLVM makedepends
 if _is_lto_kernel; then
@@ -732,4 +734,6 @@ for _p in "${pkgname[@]}"; do
 done
 
 b2sums=('524902b34e87a4093972c52eefb0347935fe43623459694ac6d4d00481d45e301df9d0c8d3b7b709d4e50aa85162221b1361f8414adec2a0b9b7c9c545511057'
-        '81fafd3adcaf3b690d8d4791693e68c7ae921d103ebfd70e8d0ae15cd05ecde5e6672ae43c3a7875686d883c1f5b82d2c8b37b40aee8dcb0563913f9dd6469b6')
+        '81fafd3adcaf3b690d8d4791693e68c7ae921d103ebfd70e8d0ae15cd05ecde5e6672ae43c3a7875686d883c1f5b82d2c8b37b40aee8dcb0563913f9dd6469b6'
+        '1b527ff75886f16c880e64e3f3292713495acdfb328c730e4574f9f2aa82aa961b2358eebbaaca3bbf95b66f829d2f0f474e3e2cbb432056d6822e1aae5e3a84'
+        'c1ea99b4cf24bc4b0860c1448374fd4004fe4be1d3428f843cc3f7df415c448e903679d5367068eb4f99fc9fe0e46b490f74c0b63b1d921102f7d06c7938f174')


### PR DESCRIPTION
Problem
HP EliteBook 845 G7 (AMD Ryzen 3 PRO 4450U, Renoir APU) suffers from a hardware-level deadlock during s2idle suspend/resume. The system enters sleep normally (power LED blinks), but becomes completely unresponsive — pressing the power button or keyboard has no effect. The only recovery is a hard power-off.

The issue is confirmed to be amdgpu-related: with nomodeset, s2idle works correctly.

Root Cause
The amdgpu driver's S0ix suspend path leaves the GPU in a partially-managed power state (GFX/PSP/MES stay active, but SMU has received power transition commands). When amd_pmc subsequently sends OS_HINT to enter S0i3, the SMU's hardware Finite State Machine encounters a conflicting GPU power state and enters an unrecoverable deadlock. The CPU completes MWAIT entry but the SoC cannot process wake interrupts.

Solution
Two DMI-based quirks for the HP EliteBook 845 G7:

Disable PSP Trusted Applications (psp_v12_0.c): Sets size_bytes = 0 for HDCP, DTM, RAP, and SECUREDISPLAY contexts, preventing their loading. This ensures psp_suspend() doesn't hang when terminating TAs during the full shutdown.

Force S3-style full GPU suspend (amdgpu_acpi.c): Makes amdgpu_acpi_is_s3_active() return true and amdgpu_acpi_is_s0ix_active() return false for this laptop. This forces the driver to perform a complete shutdown of all GPU IP blocks (GFX, PSP, SMC, DCE, SDMA, VCN, etc.) before the platform enters s2idle/S0i3. The amd_pmc driver still handles the platform-level S0i3 transition.

Testing
Hardware: HP EliteBook 845 G7 Notebook PC (AMD Ryzen 3 PRO 4450U)
Kernel: CachyOS LTS 6.18.x
Result: System now reliably enters and exits s2idle. Multiple suspend/resume cycles tested successfully.
