### PR TITLE
Fix build scripts continuing after Docker failures

### DIFF
--- a/script-v3-v4.sh
+++ b/script-v3-v4.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+run_kernelbuild() {
+    local image="$1"
+    local status
+
+    if time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v "$PWD":/pkg "$image"; then
+        status=0
+    else
+        status=$?
+    fi
+
+    docker rm kernelbuild >/dev/null 2>&1 || true
+    return "$status"
+}
+
 ## Enable ZFS
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_zfs:=no/_build_zfs:=yes/" {}
 ## Enable Generic v3
@@ -19,8 +35,7 @@ for f in $files
 do
     d=$(dirname $f)
     cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg-v3
-    docker rm kernelbuild
+    run_kernelbuild pttrr/docker-makepkg-v3
     cd ..
 done
 
@@ -33,8 +48,7 @@ for f in $files
 do
     d=$(dirname $f)
     cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg-v3
-    docker rm kernelbuild
+    run_kernelbuild pttrr/docker-makepkg-v3
     cd ..
 done
 
@@ -54,8 +68,7 @@ for f in $files
 do
     d=$(dirname $f)
     cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg-v4
-    docker rm kernelbuild
+    run_kernelbuild pttrr/docker-makepkg-v4
     cd ..
 done
 
@@ -68,8 +81,7 @@ for f in $files
 do
     d=$(dirname $f)
     cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg-v4
-    docker rm kernelbuild
+    run_kernelbuild pttrr/docker-makepkg-v4
     cd ..
 done
 

--- a/script-znver4.sh
+++ b/script-znver4.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+run_kernelbuild() {
+    local image="$1"
+    local status
+
+    if time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v "$PWD":/pkg "$image"; then
+        status=0
+    else
+        status=$?
+    fi
+
+    docker rm kernelbuild >/dev/null 2>&1 || true
+    return "$status"
+}
+
 ## Enable ZFS
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_build_zfs:=no/_build_zfs:=yes/" {}
 ## Enable Zen 4
@@ -17,8 +33,7 @@ for f in $files
 do
     d=$(dirname $f)
     cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg-znver4
-    docker rm kernelbuild
+    run_kernelbuild pttrr/docker-makepkg-znver4
     cd ..
 done
 

--- a/script.sh
+++ b/script.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+run_kernelbuild() {
+    local image="$1"
+    local status
+
+    if time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v "$PWD":/pkg "$image"; then
+        status=0
+    else
+        status=$?
+    fi
+
+    docker rm kernelbuild >/dev/null 2>&1 || true
+    return "$status"
+}
+
 ## Enable Generic
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_processor_opt:=/_processor_opt:=GENERIC/" {}
 find . -name "PKGBUILD" | xargs -I {} sed -i "s/_use_auto_optimization:=yes/_use_auto_optimization:=no/" {}
@@ -15,8 +31,7 @@ for f in $files
 do
     d=$(dirname $f)
     cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg
-    docker rm kernelbuild
+    run_kernelbuild pttrr/docker-makepkg
     cd ..
 done
 


### PR DESCRIPTION
  ## Summary

  Fix the kernel build helper scripts so Docker build failures are not masked by the following cleanup step.

  Currently, if `docker run` fails, the scripts still run `docker rm kernelbuild` and can continue into package movement and repository update steps. In a forced-failure test this allowed the script to finish with exit code `0`, even
  though no package was built.

  This change adds a small `run_kernelbuild()` wrapper that:

  - runs the selected Docker build image
  - stores the original `docker run` exit status
  - removes the `kernelbuild` container
  - returns the original build status

  With `set -euo pipefail`, a failed Docker build now stops the script before package movement or repo update.

  Changed scripts:

  - `script.sh`
  - `script-v3-v4.sh`
  - `script-znver4.sh`

## Note about `set -euo pipefail`

  This enables stricter Bash error handling for the build helper scripts:

  - `set -e`: stop the script when a command returns a non-zero exit code
  - `set -u`: fail on unset variables instead of silently expanding them to an empty string
  - `set -o pipefail`: make pipelines fail if any command in the pipeline fails, not only the last command

  The important behavior for this fix is `set -e`: `run_kernelbuild()` returns the original `docker run` exit code, so a failed Docker build now stops the script before package movement or `repo-manage-util update`.


