### PR TITLE
scripts: isolate directory navigation using subshells to fix path state corruption

### DIFF
--- a/script-v3-v4.sh
+++ b/script-v3-v4.sh
@@ -17,11 +17,12 @@ files=$(find . -name "PKGBUILD")
 
 for f in $files
 do
-    d=$(dirname $f)
-    cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg-v3
-    docker rm kernelbuild
-    cd ..
+    d=$(dirname "$f")
+    (
+        cd "$d" || exit 1
+        time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v "$PWD":/pkg pttrr/docker-makepkg-v3
+        docker rm kernelbuild
+    )
 done
 
 ## LLVM ThinLTO v3 Kernel
@@ -31,11 +32,12 @@ files=$(find . -name "PKGBUILD")
 
 for f in $files
 do
-    d=$(dirname $f)
-    cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg-v3
-    docker rm kernelbuild
-    cd ..
+    d=$(dirname "$f")
+    (
+        cd "$d" || exit 1
+        time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v "$PWD":/pkg pttrr/docker-makepkg-v3
+        docker rm kernelbuild
+    )
 done
 
 echo "move kernels to the repo"
@@ -52,11 +54,12 @@ files=$(find . -name "PKGBUILD")
 
 for f in $files
 do
-    d=$(dirname $f)
-    cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg-v4
-    docker rm kernelbuild
-    cd ..
+    d=$(dirname "$f")
+    (
+        cd "$d" || exit 1
+        time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v "$PWD":/pkg pttrr/docker-makepkg-v4
+        docker rm kernelbuild
+    )
 done
 
 ## LLVM ThinLTO v4 Kernel
@@ -66,11 +69,12 @@ files=$(find . -name "PKGBUILD")
 
 for f in $files
 do
-    d=$(dirname $f)
-    cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg-v4
-    docker rm kernelbuild
-    cd ..
+    d=$(dirname "$f")
+    (
+        cd "$d" || exit 1
+        time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v "$PWD":/pkg pttrr/docker-makepkg-v4
+        docker rm kernelbuild
+    )
 done
 
 echo "move kernels to the repo"

--- a/script-znver4.sh
+++ b/script-znver4.sh
@@ -15,11 +15,12 @@ files=$(find . -name "PKGBUILD")
 
 for f in $files
 do
-    d=$(dirname $f)
-    cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg-znver4
-    docker rm kernelbuild
-    cd ..
+    d=$(dirname "$f")
+    (
+        cd "$d" || exit 1
+        time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v "$PWD":/pkg pttrr/docker-makepkg-znver4
+        docker rm kernelbuild
+    )
 done
 
 echo "move kernels to the repo"

--- a/script.sh
+++ b/script.sh
@@ -13,11 +13,12 @@ files=$(find . -name "PKGBUILD")
 
 for f in $files
 do
-    d=$(dirname $f)
-    cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg
-    docker rm kernelbuild
-    cd ..
+    d=$(dirname "$f")
+    (
+        cd "$d" || exit 1
+        time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v "$PWD":/pkg pttrr/docker-makepkg
+        docker rm kernelbuild
+    )
 done
 
 echo "move kernels to the repo"

--- a/srcinfo.sh
+++ b/srcinfo.sh
@@ -4,10 +4,11 @@ files=$(find . -name "PKGBUILD")
 
 for f in $files
 do
-  d=$(dirname $f)
-  cd $d
-  updpkgsums
-  makepkg --printsrcinfo > .SRCINFO
-  rm -rf *.patch
-  cd ..
+  d=$(dirname "$f")
+  (
+    cd "$d" || exit 1
+    updpkgsums
+    makepkg --printsrcinfo > .SRCINFO
+    rm -rf *.patch
+  )
 done


### PR DESCRIPTION
Problem:
In `script.sh`, `script-znver4.sh`, `script-v3-v4.sh`, and `srcinfo.sh`, directory navigation inside PKGBUILD processing loops relies on `cd $d` followed by `cd ..`. This pattern suffers from critical flaws:
1. It assumes `$d` is always exactly one directory level below the root. If `find` returns nested directory paths (e.g., `./dir1/dir2/PKGBUILD`), `cd ..` steps back only one level instead of returning to the repository root.
2. If `cd $d` fails for any reason (e.g., unquoted variables or missing permissions), `cd ..` executes from the wrong working directory, causing all subsequent loop iterations to run in invalid paths and corrupting the build process.

Solution:
Wrap each package build and metadata generation step inside a subshell block `( cd "$d" || exit 1; ... )`. Because working directory modifications inside subshell processes do not persist after subshell termination:
- The main shell context remains securely in the repository root directory at all times.
- Eliminates the need for manual `cd ..` calls.
- Properly quotes path variables `"$d"` to safely handle paths containing spaces.
