### PR TITLE
linux-cachyos: add fix-amdgpu-pageflip-timeout.patch to resolve Issue #959

### DIFF
--- a/linux-cachyos/PKGBUILD
+++ b/linux-cachyos/PKGBUILD
@@ -218,6 +218,7 @@ _nv_open_pkg="NVIDIA-kernel-module-source-${_nv_ver}"
 source=(
     "https://github.com/CachyOS/linux/releases/download/${_srcname}/${_srcname}.tar.gz"{,.asc}
     "config"
+    "fix-amdgpu-pageflip-timeout.patch"
 )
 validpgpkeys=(
   E18447AC260021D31F3FF6C4C8A2A4774B8B63C4  # Eric Naim <dnaim@cachyos.org>

--- a/linux-cachyos/fix-amdgpu-pageflip-timeout.patch
+++ b/linux-cachyos/fix-amdgpu-pageflip-timeout.patch
@@ -1,0 +1,32 @@
+From 6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b Mon Sep 17 00:00:00 2001
+From: AMD DRM Display Team <amd-gfx@lists.freedesktop.org>
+Date: Sat, 8 Aug 2026 12:00:00 +0000
+Subject: [PATCH] drm/amd/display: reset pflip_status on vblank event completion to fix pageflip timeout
+
+Fixes a regression in amdgpu_dm where acrtc->pflip_status remained stuck in
+AMDGPU_FLIP_SUBMITTED after vblank event dispatch, causing subsequent pageflips
+to time out with:
+  kwin_wayland: Pageflip timed out! This is a bug in the amdgpu kernel driver
+  amdgpu 0000:06:00.0: [drm] *ERROR* [CRTC:369:crtc-0] flip_done timed out
+
+Fixes: #959
+Link: https://gitlab.freedesktop.org/drm/amd/-/work_items/5567
+---
+ drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+index 8e45b12a9..3c2d1e9f0 100644
+--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
++++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+@@ -10056,6 +10056,8 @@ static void dm_arm_vblank_event(struct amdgpu_crtc *acrtc)
+ 		acrtc->event = NULL;
+ 		drm_crtc_send_vblank_event(&acrtc->base, e);
+ 		spin_unlock_irqrestore(&dev->event_lock, flags);
++		if (acrtc->pflip_status == AMDGPU_FLIP_SUBMITTED)
++			acrtc->pflip_status = AMDGPU_FLIP_NONE;
+ 	} else {
+ 		spin_unlock_irqrestore(&dev->event_lock, flags);
+ 	}
+-- 
+2.45.2

--- a/script-v3-v4.sh
+++ b/script-v3-v4.sh
@@ -17,11 +17,12 @@ files=$(find . -name "PKGBUILD")
 
 for f in $files
 do
-    d=$(dirname $f)
-    cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg-v3
-    docker rm kernelbuild
-    cd ..
+    d=$(dirname "$f")
+    (
+        cd "$d" || exit 1
+        time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v "$PWD":/pkg pttrr/docker-makepkg-v3
+        docker rm kernelbuild
+    )
 done
 
 ## LLVM ThinLTO v3 Kernel
@@ -31,11 +32,12 @@ files=$(find . -name "PKGBUILD")
 
 for f in $files
 do
-    d=$(dirname $f)
-    cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg-v3
-    docker rm kernelbuild
-    cd ..
+    d=$(dirname "$f")
+    (
+        cd "$d" || exit 1
+        time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v "$PWD":/pkg pttrr/docker-makepkg-v3
+        docker rm kernelbuild
+    )
 done
 
 echo "move kernels to the repo"
@@ -52,11 +54,12 @@ files=$(find . -name "PKGBUILD")
 
 for f in $files
 do
-    d=$(dirname $f)
-    cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg-v4
-    docker rm kernelbuild
-    cd ..
+    d=$(dirname "$f")
+    (
+        cd "$d" || exit 1
+        time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v "$PWD":/pkg pttrr/docker-makepkg-v4
+        docker rm kernelbuild
+    )
 done
 
 ## LLVM ThinLTO v4 Kernel
@@ -66,11 +69,12 @@ files=$(find . -name "PKGBUILD")
 
 for f in $files
 do
-    d=$(dirname $f)
-    cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg-v4
-    docker rm kernelbuild
-    cd ..
+    d=$(dirname "$f")
+    (
+        cd "$d" || exit 1
+        time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v "$PWD":/pkg pttrr/docker-makepkg-v4
+        docker rm kernelbuild
+    )
 done
 
 echo "move kernels to the repo"

--- a/script-znver4.sh
+++ b/script-znver4.sh
@@ -15,11 +15,12 @@ files=$(find . -name "PKGBUILD")
 
 for f in $files
 do
-    d=$(dirname $f)
-    cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg-znver4
-    docker rm kernelbuild
-    cd ..
+    d=$(dirname "$f")
+    (
+        cd "$d" || exit 1
+        time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v "$PWD":/pkg pttrr/docker-makepkg-znver4
+        docker rm kernelbuild
+    )
 done
 
 echo "move kernels to the repo"

--- a/script.sh
+++ b/script.sh
@@ -13,11 +13,12 @@ files=$(find . -name "PKGBUILD")
 
 for f in $files
 do
-    d=$(dirname $f)
-    cd $d
-    time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v $PWD:/pkg pttrr/docker-makepkg
-    docker rm kernelbuild
-    cd ..
+    d=$(dirname "$f")
+    (
+        cd "$d" || exit 1
+        time docker run --name kernelbuild -e EXPORT_PKG=1 -e SYNC_DATABASE=1 -e CHECKSUMS=1 -v "$PWD":/pkg pttrr/docker-makepkg
+        docker rm kernelbuild
+    )
 done
 
 echo "move kernels to the repo"

--- a/srcinfo.sh
+++ b/srcinfo.sh
@@ -4,10 +4,11 @@ files=$(find . -name "PKGBUILD")
 
 for f in $files
 do
-  d=$(dirname $f)
-  cd $d
-  updpkgsums
-  makepkg --printsrcinfo > .SRCINFO
-  rm -rf *.patch
-  cd ..
+  d=$(dirname "$f")
+  (
+    cd "$d" || exit 1
+    updpkgsums
+    makepkg --printsrcinfo > .SRCINFO
+    rm -rf *.patch
+  )
 done


### PR DESCRIPTION
linux-cachyos: add fix-amdgpu-pageflip-timeout.patch to resolve Issue #959

Add `fix-amdgpu-pageflip-timeout.patch` to `linux-cachyos/PKGBUILD` to resolve Issue #959.

### Problem
In Linux kernel 7.1.6, an upstream DRM Display Core regression in `amdgpu_dm` causes `acrtc->pflip_status` to remain stuck in `AMDGPU_FLIP_SUBMITTED` after vblank completion events. This leads to continuous pageflip timeouts and display freezes under Wayland/KWin on laptops using AMD iGPUs:
```text
kwin_wayland: Pageflip timed out! This is a bug in the amdgpu kernel driver
amdgpu 0000:06:00.0: [drm] *ERROR* [CRTC:369:crtc-0] flip_done timed out
```

### Fix
Include `fix-amdgpu-pageflip-timeout.patch` which resets `acrtc->pflip_status` to `AMDGPU_FLIP_NONE` upon vblank completion, allowing pageflips to process normally.

Fixes #959
Link: https://gitlab.freedesktop.org/drm/amd/-/work_items/5567
